### PR TITLE
fix: query/path/headers parameters are mixed when evaluating required params

### DIFF
--- a/.changeset/spicy-dolls-press.md
+++ b/.changeset/spicy-dolls-press.md
@@ -1,0 +1,5 @@
+---
+"typed-openapi": patch
+---
+
+fix: query/path/headers parameters are all marked as required if one of them is required

--- a/packages/typed-openapi/src/map-openapi-endpoints.ts
+++ b/packages/typed-openapi/src/map-openapi-endpoints.ts
@@ -39,14 +39,22 @@ export const mapOpenApiEndpoints = (doc: OpenAPIObject) => {
         (acc, paramOrRef) => {
           const param = refs.unwrap(paramOrRef);
           const schema = openApiSchemaToTs({ schema: refs.unwrap(param.schema ?? {}), ctx });
-          lists.query.push(param);
 
           if (param.required) endpoint.meta.areParametersRequired = true;
           endpoint.meta.hasParameters = true;
 
-          if (param.in === "query") acc.query[param.name] = schema;
-          if (param.in === "path") acc.path[param.name] = schema;
-          if (param.in === "header") acc.header[param.name] = schema;
+          if (param.in === "query") {
+            lists.query.push(param);
+            acc.query[param.name] = schema;
+          }
+          if (param.in === "path") {
+            lists.path.push(param);
+            acc.path[param.name] = schema;
+          }
+          if (param.in === "header") {
+            lists.header.push(param);
+            acc.header[param.name] = schema;
+          }
 
           return acc;
         },

--- a/packages/typed-openapi/tests/generator.test.ts
+++ b/packages/typed-openapi/tests/generator.test.ts
@@ -88,7 +88,7 @@ describe("generator", () => {
           method: "POST";
           path: "/pet/{petId}";
           parameters: {
-            query: { name: string; status: string };
+            query: Partial<{ name: string; status: string }>;
             path: { petId: number };
           };
           response: unknown;
@@ -98,7 +98,7 @@ describe("generator", () => {
           path: "/pet/{petId}";
           parameters: {
             path: { petId: number };
-            header: { api_key: string };
+            header: Partial<{ api_key: string }>;
           };
           response: unknown;
         };
@@ -106,7 +106,7 @@ describe("generator", () => {
           method: "POST";
           path: "/pet/{petId}/uploadImage";
           parameters: {
-            query: { additionalMetadata: string };
+            query: Partial<{ additionalMetadata: string }>;
             path: { petId: number };
           };
           response: Schemas.ApiResponse;

--- a/packages/typed-openapi/tests/map-openapi-endpoints.test.ts
+++ b/packages/typed-openapi/tests/map-openapi-endpoints.test.ts
@@ -1695,14 +1695,8 @@ describe("map-openapi-endpoints", () => {
                 },
               },
               "query": {
-                "name": {
-                  "type": "keyword",
-                  "value": "string",
-                },
-                "status": {
-                  "type": "keyword",
-                  "value": "string",
-                },
+                "type": "ref",
+                "value": "Partial<{ name: string, status: string }>",
               },
             },
             "path": "/pet/{petId}",
@@ -1762,10 +1756,8 @@ describe("map-openapi-endpoints", () => {
             },
             "parameters": {
               "header": {
-                "api_key": {
-                  "type": "keyword",
-                  "value": "string",
-                },
+                "type": "ref",
+                "value": "Partial<{ api_key: string }>",
               },
               "path": {
                 "petId": {
@@ -1858,10 +1850,8 @@ describe("map-openapi-endpoints", () => {
                 },
               },
               "query": {
-                "additionalMetadata": {
-                  "type": "keyword",
-                  "value": "string",
-                },
+                "type": "ref",
+                "value": "Partial<{ additionalMetadata: string }>",
               },
             },
             "path": "/pet/{petId}/uploadImage",

--- a/packages/typed-openapi/tests/snapshots/docker.openapi.client.ts
+++ b/packages/typed-openapi/tests/snapshots/docker.openapi.client.ts
@@ -870,7 +870,7 @@ export namespace Endpoints {
     method: "GET";
     path: "/containers/{id}/json";
     parameters: {
-      query: { size: boolean };
+      query: Partial<{ size: boolean }>;
       path: { id: string };
     };
     response: Partial<{
@@ -905,7 +905,7 @@ export namespace Endpoints {
     method: "GET";
     path: "/containers/{id}/top";
     parameters: {
-      query: { ps_args: string };
+      query: Partial<{ ps_args: string }>;
       path: { id: string };
     };
     response: Partial<{ Titles: Array<string>; Processes: Array<Array<string>> }>;
@@ -914,7 +914,7 @@ export namespace Endpoints {
     method: "GET";
     path: "/containers/{id}/logs";
     parameters: {
-      query: {
+      query: Partial<{
         follow: boolean;
         stdout: boolean;
         stderr: boolean;
@@ -922,7 +922,7 @@ export namespace Endpoints {
         until: number;
         timestamps: boolean;
         tail: string;
-      };
+      }>;
       path: { id: string };
     };
     response: unknown;
@@ -947,7 +947,7 @@ export namespace Endpoints {
     method: "GET";
     path: "/containers/{id}/stats";
     parameters: {
-      query: { stream: boolean; "one-shot": boolean };
+      query: Partial<{ stream: boolean; "one-shot": boolean }>;
       path: { id: string };
     };
     response: unknown;
@@ -956,7 +956,7 @@ export namespace Endpoints {
     method: "POST";
     path: "/containers/{id}/resize";
     parameters: {
-      query: { h: number; w: number };
+      query: Partial<{ h: number; w: number }>;
       path: { id: string };
     };
     response: unknown;
@@ -965,7 +965,7 @@ export namespace Endpoints {
     method: "POST";
     path: "/containers/{id}/start";
     parameters: {
-      query: { detachKeys: string };
+      query: Partial<{ detachKeys: string }>;
       path: { id: string };
     };
     response: unknown;
@@ -974,7 +974,7 @@ export namespace Endpoints {
     method: "POST";
     path: "/containers/{id}/stop";
     parameters: {
-      query: { signal: string; t: number };
+      query: Partial<{ signal: string; t: number }>;
       path: { id: string };
     };
     response: unknown;
@@ -983,7 +983,7 @@ export namespace Endpoints {
     method: "POST";
     path: "/containers/{id}/restart";
     parameters: {
-      query: { signal: string; t: number };
+      query: Partial<{ signal: string; t: number }>;
       path: { id: string };
     };
     response: unknown;
@@ -992,7 +992,7 @@ export namespace Endpoints {
     method: "POST";
     path: "/containers/{id}/kill";
     parameters: {
-      query: { signal: string };
+      query: Partial<{ signal: string }>;
       path: { id: string };
     };
     response: unknown;
@@ -1034,7 +1034,14 @@ export namespace Endpoints {
     method: "POST";
     path: "/containers/{id}/attach";
     parameters: {
-      query: { detachKeys: string; logs: boolean; stream: boolean; stdin: boolean; stdout: boolean; stderr: boolean };
+      query: Partial<{
+        detachKeys: string;
+        logs: boolean;
+        stream: boolean;
+        stdin: boolean;
+        stdout: boolean;
+        stderr: boolean;
+      }>;
       path: { id: string };
     };
     response: unknown;
@@ -1043,7 +1050,14 @@ export namespace Endpoints {
     method: "GET";
     path: "/containers/{id}/attach/ws";
     parameters: {
-      query: { detachKeys: string; logs: boolean; stream: boolean; stdin: boolean; stdout: boolean; stderr: boolean };
+      query: Partial<{
+        detachKeys: string;
+        logs: boolean;
+        stream: boolean;
+        stdin: boolean;
+        stdout: boolean;
+        stderr: boolean;
+      }>;
       path: { id: string };
     };
     response: unknown;
@@ -1052,7 +1066,7 @@ export namespace Endpoints {
     method: "POST";
     path: "/containers/{id}/wait";
     parameters: {
-      query: { condition: "not-running" | "next-exit" | "removed" };
+      query: Partial<{ condition: "not-running" | "next-exit" | "removed" }>;
       path: { id: string };
     };
     response: Schemas.ContainerWaitResponse;
@@ -1061,7 +1075,7 @@ export namespace Endpoints {
     method: "DELETE";
     path: "/containers/{id}";
     parameters: {
-      query: { v: boolean; force: boolean; link: boolean };
+      query: Partial<{ v: boolean; force: boolean; link: boolean }>;
       path: { id: string };
     };
     response: unknown;
@@ -1140,7 +1154,7 @@ export namespace Endpoints {
         outputs: string;
       }>;
 
-      header: { "Content-type": "application/x-tar"; "X-Registry-Config": string };
+      header: Partial<{ "Content-type": "application/x-tar"; "X-Registry-Config": string }>;
     };
     response: unknown;
   };
@@ -1166,7 +1180,7 @@ export namespace Endpoints {
         platform: string;
       }>;
 
-      header: { "X-Registry-Auth": string };
+      header: Partial<{ "X-Registry-Auth": string }>;
     };
     response: unknown;
   };
@@ -1197,7 +1211,7 @@ export namespace Endpoints {
     method: "POST";
     path: "/images/{name}/push";
     parameters: {
-      query: { tag: string };
+      query: Partial<{ tag: string }>;
       path: { name: string };
       header: { "X-Registry-Auth": string };
     };
@@ -1207,7 +1221,7 @@ export namespace Endpoints {
     method: "POST";
     path: "/images/{name}/tag";
     parameters: {
-      query: { repo: string; tag: string };
+      query: Partial<{ repo: string; tag: string }>;
       path: { name: string };
     };
     response: unknown;
@@ -1216,7 +1230,7 @@ export namespace Endpoints {
     method: "DELETE";
     path: "/images/{name}";
     parameters: {
-      query: { force: boolean; noprune: boolean };
+      query: Partial<{ force: boolean; noprune: boolean }>;
       path: { name: string };
     };
     response: Array<Schemas.ImageDeleteResponseItem>;
@@ -1351,7 +1365,7 @@ export namespace Endpoints {
     method: "POST";
     path: "/exec/{id}/resize";
     parameters: {
-      query: { h: number; w: number };
+      query: Partial<{ h: number; w: number }>;
       path: { id: string };
     };
     response: unknown;
@@ -1411,7 +1425,7 @@ export namespace Endpoints {
     method: "DELETE";
     path: "/volumes/{name}";
     parameters: {
-      query: { force: boolean };
+      query: Partial<{ force: boolean }>;
       path: { name: string };
     };
     response: unknown;
@@ -1436,7 +1450,7 @@ export namespace Endpoints {
     method: "GET";
     path: "/networks/{id}";
     parameters: {
-      query: { verbose: boolean; scope: string };
+      query: Partial<{ verbose: boolean; scope: string }>;
       path: { id: string };
     };
     response: Schemas.Network;
@@ -1501,7 +1515,7 @@ export namespace Endpoints {
     parameters: {
       query: { remote: string; name: string };
 
-      header: { "X-Registry-Auth": string };
+      header: Partial<{ "X-Registry-Auth": string }>;
     };
     response: unknown;
   };
@@ -1517,7 +1531,7 @@ export namespace Endpoints {
     method: "DELETE";
     path: "/plugins/{name}";
     parameters: {
-      query: { force: boolean };
+      query: Partial<{ force: boolean }>;
       path: { name: string };
     };
     response: Schemas.Plugin;
@@ -1526,7 +1540,7 @@ export namespace Endpoints {
     method: "POST";
     path: "/plugins/{name}/enable";
     parameters: {
-      query: { timeout: number };
+      query: Partial<{ timeout: number }>;
       path: { name: string };
     };
     response: unknown;
@@ -1535,7 +1549,7 @@ export namespace Endpoints {
     method: "POST";
     path: "/plugins/{name}/disable";
     parameters: {
-      query: { force: boolean };
+      query: Partial<{ force: boolean }>;
       path: { name: string };
     };
     response: unknown;
@@ -1546,7 +1560,7 @@ export namespace Endpoints {
     parameters: {
       query: { remote: string };
       path: { name: string };
-      header: { "X-Registry-Auth": string };
+      header: Partial<{ "X-Registry-Auth": string }>;
     };
     response: unknown;
   };
@@ -1594,7 +1608,7 @@ export namespace Endpoints {
     method: "DELETE";
     path: "/nodes/{id}";
     parameters: {
-      query: { force: boolean };
+      query: Partial<{ force: boolean }>;
       path: { id: string };
     };
     response: unknown;
@@ -1671,7 +1685,7 @@ export namespace Endpoints {
     method: "POST";
     path: "/services/create";
     parameters: {
-      header: { "X-Registry-Auth": string };
+      header: Partial<{ "X-Registry-Auth": string }>;
     };
     response: Partial<{ ID: string; Warning: string }>;
   };
@@ -1679,7 +1693,7 @@ export namespace Endpoints {
     method: "GET";
     path: "/services/{id}";
     parameters: {
-      query: { insertDefaults: boolean };
+      query: Partial<{ insertDefaults: boolean }>;
       path: { id: string };
     };
     response: Schemas.Service;
@@ -1698,7 +1712,7 @@ export namespace Endpoints {
     parameters: {
       query: { version: number; registryAuthFrom: "spec" | "previous-spec"; rollback: string };
       path: { id: string };
-      header: { "X-Registry-Auth": string };
+      header: Partial<{ "X-Registry-Auth": string }>;
     };
     response: Schemas.ServiceUpdateResponse;
   };
@@ -1706,7 +1720,7 @@ export namespace Endpoints {
     method: "GET";
     path: "/services/{id}/logs";
     parameters: {
-      query: {
+      query: Partial<{
         details: boolean;
         follow: boolean;
         stdout: boolean;
@@ -1714,7 +1728,7 @@ export namespace Endpoints {
         since: number;
         timestamps: boolean;
         tail: string;
-      };
+      }>;
       path: { id: string };
     };
     response: unknown;
@@ -1739,7 +1753,7 @@ export namespace Endpoints {
     method: "GET";
     path: "/tasks/{id}/logs";
     parameters: {
-      query: {
+      query: Partial<{
         details: boolean;
         follow: boolean;
         stdout: boolean;
@@ -1747,7 +1761,7 @@ export namespace Endpoints {
         since: number;
         timestamps: boolean;
         tail: string;
-      };
+      }>;
       path: { id: string };
     };
     response: unknown;

--- a/packages/typed-openapi/tests/snapshots/docker.openapi.io-ts.ts
+++ b/packages/typed-openapi/tests/snapshots/docker.openapi.io-ts.ts
@@ -1758,7 +1758,7 @@ export const get_ContainerInspect = t.type({
   path: t.literal("/containers/{id}/json"),
   parameters: t.type({
     query: t.type({
-      size: t.boolean,
+      size: t.union([t.undefined, t.boolean]),
     }),
     path: t.type({
       id: t.string,
@@ -1799,7 +1799,7 @@ export const get_ContainerTop = t.type({
   path: t.literal("/containers/{id}/top"),
   parameters: t.type({
     query: t.type({
-      ps_args: t.string,
+      ps_args: t.union([t.undefined, t.string]),
     }),
     path: t.type({
       id: t.string,
@@ -1817,13 +1817,13 @@ export const get_ContainerLogs = t.type({
   path: t.literal("/containers/{id}/logs"),
   parameters: t.type({
     query: t.type({
-      follow: t.boolean,
-      stdout: t.boolean,
-      stderr: t.boolean,
-      since: t.number,
-      until: t.number,
-      timestamps: t.boolean,
-      tail: t.string,
+      follow: t.union([t.undefined, t.boolean]),
+      stdout: t.union([t.undefined, t.boolean]),
+      stderr: t.union([t.undefined, t.boolean]),
+      since: t.union([t.undefined, t.number]),
+      until: t.union([t.undefined, t.number]),
+      timestamps: t.union([t.undefined, t.boolean]),
+      tail: t.union([t.undefined, t.string]),
     }),
     path: t.type({
       id: t.string,
@@ -1862,8 +1862,8 @@ export const get_ContainerStats = t.type({
   path: t.literal("/containers/{id}/stats"),
   parameters: t.type({
     query: t.type({
-      stream: t.boolean,
-      "one-shot": t.boolean,
+      stream: t.union([t.undefined, t.boolean]),
+      "one-shot": t.union([t.undefined, t.boolean]),
     }),
     path: t.type({
       id: t.string,
@@ -1878,8 +1878,8 @@ export const post_ContainerResize = t.type({
   path: t.literal("/containers/{id}/resize"),
   parameters: t.type({
     query: t.type({
-      h: t.number,
-      w: t.number,
+      h: t.union([t.undefined, t.number]),
+      w: t.union([t.undefined, t.number]),
     }),
     path: t.type({
       id: t.string,
@@ -1894,7 +1894,7 @@ export const post_ContainerStart = t.type({
   path: t.literal("/containers/{id}/start"),
   parameters: t.type({
     query: t.type({
-      detachKeys: t.string,
+      detachKeys: t.union([t.undefined, t.string]),
     }),
     path: t.type({
       id: t.string,
@@ -1909,8 +1909,8 @@ export const post_ContainerStop = t.type({
   path: t.literal("/containers/{id}/stop"),
   parameters: t.type({
     query: t.type({
-      signal: t.string,
-      t: t.number,
+      signal: t.union([t.undefined, t.string]),
+      t: t.union([t.undefined, t.number]),
     }),
     path: t.type({
       id: t.string,
@@ -1925,8 +1925,8 @@ export const post_ContainerRestart = t.type({
   path: t.literal("/containers/{id}/restart"),
   parameters: t.type({
     query: t.type({
-      signal: t.string,
-      t: t.number,
+      signal: t.union([t.undefined, t.string]),
+      t: t.union([t.undefined, t.number]),
     }),
     path: t.type({
       id: t.string,
@@ -1941,7 +1941,7 @@ export const post_ContainerKill = t.type({
   path: t.literal("/containers/{id}/kill"),
   parameters: t.type({
     query: t.type({
-      signal: t.string,
+      signal: t.union([t.undefined, t.string]),
     }),
     path: t.type({
       id: t.string,
@@ -2009,12 +2009,12 @@ export const post_ContainerAttach = t.type({
   path: t.literal("/containers/{id}/attach"),
   parameters: t.type({
     query: t.type({
-      detachKeys: t.string,
-      logs: t.boolean,
-      stream: t.boolean,
-      stdin: t.boolean,
-      stdout: t.boolean,
-      stderr: t.boolean,
+      detachKeys: t.union([t.undefined, t.string]),
+      logs: t.union([t.undefined, t.boolean]),
+      stream: t.union([t.undefined, t.boolean]),
+      stdin: t.union([t.undefined, t.boolean]),
+      stdout: t.union([t.undefined, t.boolean]),
+      stderr: t.union([t.undefined, t.boolean]),
     }),
     path: t.type({
       id: t.string,
@@ -2029,12 +2029,12 @@ export const get_ContainerAttachWebsocket = t.type({
   path: t.literal("/containers/{id}/attach/ws"),
   parameters: t.type({
     query: t.type({
-      detachKeys: t.string,
-      logs: t.boolean,
-      stream: t.boolean,
-      stdin: t.boolean,
-      stdout: t.boolean,
-      stderr: t.boolean,
+      detachKeys: t.union([t.undefined, t.string]),
+      logs: t.union([t.undefined, t.boolean]),
+      stream: t.union([t.undefined, t.boolean]),
+      stdin: t.union([t.undefined, t.boolean]),
+      stdout: t.union([t.undefined, t.boolean]),
+      stderr: t.union([t.undefined, t.boolean]),
     }),
     path: t.type({
       id: t.string,
@@ -2049,7 +2049,10 @@ export const post_ContainerWait = t.type({
   path: t.literal("/containers/{id}/wait"),
   parameters: t.type({
     query: t.type({
-      condition: t.union([t.literal("not-running"), t.literal("next-exit"), t.literal("removed")]),
+      condition: t.union([
+        t.undefined,
+        t.union([t.literal("not-running"), t.literal("next-exit"), t.literal("removed")]),
+      ]),
     }),
     path: t.type({
       id: t.string,
@@ -2064,9 +2067,9 @@ export const delete_ContainerDelete = t.type({
   path: t.literal("/containers/{id}"),
   parameters: t.type({
     query: t.type({
-      v: t.boolean,
-      force: t.boolean,
-      link: t.boolean,
+      v: t.union([t.undefined, t.boolean]),
+      force: t.union([t.undefined, t.boolean]),
+      link: t.union([t.undefined, t.boolean]),
     }),
     path: t.type({
       id: t.string,
@@ -2184,8 +2187,8 @@ export const post_ImageBuild = t.type({
       outputs: t.union([t.undefined, t.string]),
     }),
     header: t.type({
-      "Content-type": t.literal("application/x-tar"),
-      "X-Registry-Config": t.string,
+      "Content-type": t.union([t.undefined, t.literal("application/x-tar")]),
+      "X-Registry-Config": t.union([t.undefined, t.string]),
     }),
   }),
   response: t.unknown,
@@ -2223,7 +2226,7 @@ export const post_ImageCreate = t.type({
       platform: t.union([t.undefined, t.string]),
     }),
     header: t.type({
-      "X-Registry-Auth": t.string,
+      "X-Registry-Auth": t.union([t.undefined, t.string]),
     }),
   }),
   response: t.unknown,
@@ -2268,7 +2271,7 @@ export const post_ImagePush = t.type({
   path: t.literal("/images/{name}/push"),
   parameters: t.type({
     query: t.type({
-      tag: t.string,
+      tag: t.union([t.undefined, t.string]),
     }),
     path: t.type({
       name: t.string,
@@ -2286,8 +2289,8 @@ export const post_ImageTag = t.type({
   path: t.literal("/images/{name}/tag"),
   parameters: t.type({
     query: t.type({
-      repo: t.string,
-      tag: t.string,
+      repo: t.union([t.undefined, t.string]),
+      tag: t.union([t.undefined, t.string]),
     }),
     path: t.type({
       name: t.string,
@@ -2302,8 +2305,8 @@ export const delete_ImageDelete = t.type({
   path: t.literal("/images/{name}"),
   parameters: t.type({
     query: t.type({
-      force: t.boolean,
-      noprune: t.boolean,
+      force: t.union([t.undefined, t.boolean]),
+      noprune: t.union([t.undefined, t.boolean]),
     }),
     path: t.type({
       name: t.string,
@@ -2508,8 +2511,8 @@ export const post_ExecResize = t.type({
   path: t.literal("/exec/{id}/resize"),
   parameters: t.type({
     query: t.type({
-      h: t.number,
-      w: t.number,
+      h: t.union([t.undefined, t.number]),
+      w: t.union([t.undefined, t.number]),
     }),
     path: t.type({
       id: t.string,
@@ -2595,7 +2598,7 @@ export const delete_VolumeDelete = t.type({
   path: t.literal("/volumes/{name}"),
   parameters: t.type({
     query: t.type({
-      force: t.boolean,
+      force: t.union([t.undefined, t.boolean]),
     }),
     path: t.type({
       name: t.string,
@@ -2637,8 +2640,8 @@ export const get_NetworkInspect = t.type({
   path: t.literal("/networks/{id}"),
   parameters: t.type({
     query: t.type({
-      verbose: t.boolean,
-      scope: t.string,
+      verbose: t.union([t.undefined, t.boolean]),
+      scope: t.union([t.undefined, t.string]),
     }),
     path: t.type({
       id: t.string,
@@ -2742,7 +2745,7 @@ export const post_PluginPull = t.type({
       name: t.string,
     }),
     header: t.type({
-      "X-Registry-Auth": t.string,
+      "X-Registry-Auth": t.union([t.undefined, t.string]),
     }),
   }),
   response: t.unknown,
@@ -2766,7 +2769,7 @@ export const delete_PluginDelete = t.type({
   path: t.literal("/plugins/{name}"),
   parameters: t.type({
     query: t.type({
-      force: t.boolean,
+      force: t.union([t.undefined, t.boolean]),
     }),
     path: t.type({
       name: t.string,
@@ -2781,7 +2784,7 @@ export const post_PluginEnable = t.type({
   path: t.literal("/plugins/{name}/enable"),
   parameters: t.type({
     query: t.type({
-      timeout: t.number,
+      timeout: t.union([t.undefined, t.number]),
     }),
     path: t.type({
       name: t.string,
@@ -2796,7 +2799,7 @@ export const post_PluginDisable = t.type({
   path: t.literal("/plugins/{name}/disable"),
   parameters: t.type({
     query: t.type({
-      force: t.boolean,
+      force: t.union([t.undefined, t.boolean]),
     }),
     path: t.type({
       name: t.string,
@@ -2817,7 +2820,7 @@ export const post_PluginUpgrade = t.type({
       name: t.string,
     }),
     header: t.type({
-      "X-Registry-Auth": t.string,
+      "X-Registry-Auth": t.union([t.undefined, t.string]),
     }),
   }),
   response: t.unknown,
@@ -2889,7 +2892,7 @@ export const delete_NodeDelete = t.type({
   path: t.literal("/nodes/{id}"),
   parameters: t.type({
     query: t.type({
-      force: t.boolean,
+      force: t.union([t.undefined, t.boolean]),
     }),
     path: t.type({
       id: t.string,
@@ -3001,7 +3004,7 @@ export const post_ServiceCreate = t.type({
   path: t.literal("/services/create"),
   parameters: t.type({
     header: t.type({
-      "X-Registry-Auth": t.string,
+      "X-Registry-Auth": t.union([t.undefined, t.string]),
     }),
   }),
   response: t.type({
@@ -3016,7 +3019,7 @@ export const get_ServiceInspect = t.type({
   path: t.literal("/services/{id}"),
   parameters: t.type({
     query: t.type({
-      insertDefaults: t.boolean,
+      insertDefaults: t.union([t.undefined, t.boolean]),
     }),
     path: t.type({
       id: t.string,
@@ -3051,7 +3054,7 @@ export const post_ServiceUpdate = t.type({
       id: t.string,
     }),
     header: t.type({
-      "X-Registry-Auth": t.string,
+      "X-Registry-Auth": t.union([t.undefined, t.string]),
     }),
   }),
   response: ServiceUpdateResponse,
@@ -3063,13 +3066,13 @@ export const get_ServiceLogs = t.type({
   path: t.literal("/services/{id}/logs"),
   parameters: t.type({
     query: t.type({
-      details: t.boolean,
-      follow: t.boolean,
-      stdout: t.boolean,
-      stderr: t.boolean,
-      since: t.number,
-      timestamps: t.boolean,
-      tail: t.string,
+      details: t.union([t.undefined, t.boolean]),
+      follow: t.union([t.undefined, t.boolean]),
+      stdout: t.union([t.undefined, t.boolean]),
+      stderr: t.union([t.undefined, t.boolean]),
+      since: t.union([t.undefined, t.number]),
+      timestamps: t.union([t.undefined, t.boolean]),
+      tail: t.union([t.undefined, t.string]),
     }),
     path: t.type({
       id: t.string,
@@ -3108,13 +3111,13 @@ export const get_TaskLogs = t.type({
   path: t.literal("/tasks/{id}/logs"),
   parameters: t.type({
     query: t.type({
-      details: t.boolean,
-      follow: t.boolean,
-      stdout: t.boolean,
-      stderr: t.boolean,
-      since: t.number,
-      timestamps: t.boolean,
-      tail: t.string,
+      details: t.union([t.undefined, t.boolean]),
+      follow: t.union([t.undefined, t.boolean]),
+      stdout: t.union([t.undefined, t.boolean]),
+      stderr: t.union([t.undefined, t.boolean]),
+      since: t.union([t.undefined, t.number]),
+      timestamps: t.union([t.undefined, t.boolean]),
+      tail: t.union([t.undefined, t.string]),
     }),
     path: t.type({
       id: t.string,

--- a/packages/typed-openapi/tests/snapshots/docker.openapi.typebox.ts
+++ b/packages/typed-openapi/tests/snapshots/docker.openapi.typebox.ts
@@ -1851,9 +1851,11 @@ export const get_ContainerInspect = Type.Object({
   method: Type.Literal("GET"),
   path: Type.Literal("/containers/{id}/json"),
   parameters: Type.Object({
-    query: Type.Object({
-      size: Type.Boolean(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        size: Type.Boolean(),
+      }),
+    ),
     path: Type.Object({
       id: Type.String(),
     }),
@@ -1894,9 +1896,11 @@ export const get_ContainerTop = Type.Object({
   method: Type.Literal("GET"),
   path: Type.Literal("/containers/{id}/top"),
   parameters: Type.Object({
-    query: Type.Object({
-      ps_args: Type.String(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        ps_args: Type.String(),
+      }),
+    ),
     path: Type.Object({
       id: Type.String(),
     }),
@@ -1914,15 +1918,17 @@ export const get_ContainerLogs = Type.Object({
   method: Type.Literal("GET"),
   path: Type.Literal("/containers/{id}/logs"),
   parameters: Type.Object({
-    query: Type.Object({
-      follow: Type.Boolean(),
-      stdout: Type.Boolean(),
-      stderr: Type.Boolean(),
-      since: Type.Number(),
-      until: Type.Number(),
-      timestamps: Type.Boolean(),
-      tail: Type.String(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        follow: Type.Boolean(),
+        stdout: Type.Boolean(),
+        stderr: Type.Boolean(),
+        since: Type.Number(),
+        until: Type.Number(),
+        timestamps: Type.Boolean(),
+        tail: Type.String(),
+      }),
+    ),
     path: Type.Object({
       id: Type.String(),
     }),
@@ -1959,10 +1965,12 @@ export const get_ContainerStats = Type.Object({
   method: Type.Literal("GET"),
   path: Type.Literal("/containers/{id}/stats"),
   parameters: Type.Object({
-    query: Type.Object({
-      stream: Type.Boolean(),
-      "one-shot": Type.Boolean(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        stream: Type.Boolean(),
+        "one-shot": Type.Boolean(),
+      }),
+    ),
     path: Type.Object({
       id: Type.String(),
     }),
@@ -1975,10 +1983,12 @@ export const post_ContainerResize = Type.Object({
   method: Type.Literal("POST"),
   path: Type.Literal("/containers/{id}/resize"),
   parameters: Type.Object({
-    query: Type.Object({
-      h: Type.Number(),
-      w: Type.Number(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        h: Type.Number(),
+        w: Type.Number(),
+      }),
+    ),
     path: Type.Object({
       id: Type.String(),
     }),
@@ -1991,9 +2001,11 @@ export const post_ContainerStart = Type.Object({
   method: Type.Literal("POST"),
   path: Type.Literal("/containers/{id}/start"),
   parameters: Type.Object({
-    query: Type.Object({
-      detachKeys: Type.String(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        detachKeys: Type.String(),
+      }),
+    ),
     path: Type.Object({
       id: Type.String(),
     }),
@@ -2006,10 +2018,12 @@ export const post_ContainerStop = Type.Object({
   method: Type.Literal("POST"),
   path: Type.Literal("/containers/{id}/stop"),
   parameters: Type.Object({
-    query: Type.Object({
-      signal: Type.String(),
-      t: Type.Number(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        signal: Type.String(),
+        t: Type.Number(),
+      }),
+    ),
     path: Type.Object({
       id: Type.String(),
     }),
@@ -2022,10 +2036,12 @@ export const post_ContainerRestart = Type.Object({
   method: Type.Literal("POST"),
   path: Type.Literal("/containers/{id}/restart"),
   parameters: Type.Object({
-    query: Type.Object({
-      signal: Type.String(),
-      t: Type.Number(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        signal: Type.String(),
+        t: Type.Number(),
+      }),
+    ),
     path: Type.Object({
       id: Type.String(),
     }),
@@ -2038,9 +2054,11 @@ export const post_ContainerKill = Type.Object({
   method: Type.Literal("POST"),
   path: Type.Literal("/containers/{id}/kill"),
   parameters: Type.Object({
-    query: Type.Object({
-      signal: Type.String(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        signal: Type.String(),
+      }),
+    ),
     path: Type.Object({
       id: Type.String(),
     }),
@@ -2108,14 +2126,16 @@ export const post_ContainerAttach = Type.Object({
   method: Type.Literal("POST"),
   path: Type.Literal("/containers/{id}/attach"),
   parameters: Type.Object({
-    query: Type.Object({
-      detachKeys: Type.String(),
-      logs: Type.Boolean(),
-      stream: Type.Boolean(),
-      stdin: Type.Boolean(),
-      stdout: Type.Boolean(),
-      stderr: Type.Boolean(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        detachKeys: Type.String(),
+        logs: Type.Boolean(),
+        stream: Type.Boolean(),
+        stdin: Type.Boolean(),
+        stdout: Type.Boolean(),
+        stderr: Type.Boolean(),
+      }),
+    ),
     path: Type.Object({
       id: Type.String(),
     }),
@@ -2128,14 +2148,16 @@ export const get_ContainerAttachWebsocket = Type.Object({
   method: Type.Literal("GET"),
   path: Type.Literal("/containers/{id}/attach/ws"),
   parameters: Type.Object({
-    query: Type.Object({
-      detachKeys: Type.String(),
-      logs: Type.Boolean(),
-      stream: Type.Boolean(),
-      stdin: Type.Boolean(),
-      stdout: Type.Boolean(),
-      stderr: Type.Boolean(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        detachKeys: Type.String(),
+        logs: Type.Boolean(),
+        stream: Type.Boolean(),
+        stdin: Type.Boolean(),
+        stdout: Type.Boolean(),
+        stderr: Type.Boolean(),
+      }),
+    ),
     path: Type.Object({
       id: Type.String(),
     }),
@@ -2148,9 +2170,11 @@ export const post_ContainerWait = Type.Object({
   method: Type.Literal("POST"),
   path: Type.Literal("/containers/{id}/wait"),
   parameters: Type.Object({
-    query: Type.Object({
-      condition: Type.Union([Type.Literal("not-running"), Type.Literal("next-exit"), Type.Literal("removed")]),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        condition: Type.Union([Type.Literal("not-running"), Type.Literal("next-exit"), Type.Literal("removed")]),
+      }),
+    ),
     path: Type.Object({
       id: Type.String(),
     }),
@@ -2163,11 +2187,13 @@ export const delete_ContainerDelete = Type.Object({
   method: Type.Literal("DELETE"),
   path: Type.Literal("/containers/{id}"),
   parameters: Type.Object({
-    query: Type.Object({
-      v: Type.Boolean(),
-      force: Type.Boolean(),
-      link: Type.Boolean(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        v: Type.Boolean(),
+        force: Type.Boolean(),
+        link: Type.Boolean(),
+      }),
+    ),
     path: Type.Object({
       id: Type.String(),
     }),
@@ -2291,10 +2317,12 @@ export const post_ImageBuild = Type.Object({
         outputs: Type.String(),
       }),
     ),
-    header: Type.Object({
-      "Content-type": Type.Literal("application/x-tar"),
-      "X-Registry-Config": Type.String(),
-    }),
+    header: Type.Partial(
+      Type.Object({
+        "Content-type": Type.Literal("application/x-tar"),
+        "X-Registry-Config": Type.String(),
+      }),
+    ),
   }),
   response: Type.Unknown(),
 });
@@ -2336,9 +2364,11 @@ export const post_ImageCreate = Type.Object({
         platform: Type.String(),
       }),
     ),
-    header: Type.Object({
-      "X-Registry-Auth": Type.String(),
-    }),
+    header: Type.Partial(
+      Type.Object({
+        "X-Registry-Auth": Type.String(),
+      }),
+    ),
   }),
   response: Type.Unknown(),
 });
@@ -2381,9 +2411,11 @@ export const post_ImagePush = Type.Object({
   method: Type.Literal("POST"),
   path: Type.Literal("/images/{name}/push"),
   parameters: Type.Object({
-    query: Type.Object({
-      tag: Type.String(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        tag: Type.String(),
+      }),
+    ),
     path: Type.Object({
       name: Type.String(),
     }),
@@ -2399,10 +2431,12 @@ export const post_ImageTag = Type.Object({
   method: Type.Literal("POST"),
   path: Type.Literal("/images/{name}/tag"),
   parameters: Type.Object({
-    query: Type.Object({
-      repo: Type.String(),
-      tag: Type.String(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        repo: Type.String(),
+        tag: Type.String(),
+      }),
+    ),
     path: Type.Object({
       name: Type.String(),
     }),
@@ -2415,10 +2449,12 @@ export const delete_ImageDelete = Type.Object({
   method: Type.Literal("DELETE"),
   path: Type.Literal("/images/{name}"),
   parameters: Type.Object({
-    query: Type.Object({
-      force: Type.Boolean(),
-      noprune: Type.Boolean(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        force: Type.Boolean(),
+        noprune: Type.Boolean(),
+      }),
+    ),
     path: Type.Object({
       name: Type.String(),
     }),
@@ -2643,10 +2679,12 @@ export const post_ExecResize = Type.Object({
   method: Type.Literal("POST"),
   path: Type.Literal("/exec/{id}/resize"),
   parameters: Type.Object({
-    query: Type.Object({
-      h: Type.Number(),
-      w: Type.Number(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        h: Type.Number(),
+        w: Type.Number(),
+      }),
+    ),
     path: Type.Object({
       id: Type.String(),
     }),
@@ -2734,9 +2772,11 @@ export const delete_VolumeDelete = Type.Object({
   method: Type.Literal("DELETE"),
   path: Type.Literal("/volumes/{name}"),
   parameters: Type.Object({
-    query: Type.Object({
-      force: Type.Boolean(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        force: Type.Boolean(),
+      }),
+    ),
     path: Type.Object({
       name: Type.String(),
     }),
@@ -2782,10 +2822,12 @@ export const get_NetworkInspect = Type.Object({
   method: Type.Literal("GET"),
   path: Type.Literal("/networks/{id}"),
   parameters: Type.Object({
-    query: Type.Object({
-      verbose: Type.Boolean(),
-      scope: Type.String(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        verbose: Type.Boolean(),
+        scope: Type.String(),
+      }),
+    ),
     path: Type.Object({
       id: Type.String(),
     }),
@@ -2895,9 +2937,11 @@ export const post_PluginPull = Type.Object({
       remote: Type.String(),
       name: Type.String(),
     }),
-    header: Type.Object({
-      "X-Registry-Auth": Type.String(),
-    }),
+    header: Type.Partial(
+      Type.Object({
+        "X-Registry-Auth": Type.String(),
+      }),
+    ),
   }),
   response: Type.Unknown(),
 });
@@ -2919,9 +2963,11 @@ export const delete_PluginDelete = Type.Object({
   method: Type.Literal("DELETE"),
   path: Type.Literal("/plugins/{name}"),
   parameters: Type.Object({
-    query: Type.Object({
-      force: Type.Boolean(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        force: Type.Boolean(),
+      }),
+    ),
     path: Type.Object({
       name: Type.String(),
     }),
@@ -2934,9 +2980,11 @@ export const post_PluginEnable = Type.Object({
   method: Type.Literal("POST"),
   path: Type.Literal("/plugins/{name}/enable"),
   parameters: Type.Object({
-    query: Type.Object({
-      timeout: Type.Number(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        timeout: Type.Number(),
+      }),
+    ),
     path: Type.Object({
       name: Type.String(),
     }),
@@ -2949,9 +2997,11 @@ export const post_PluginDisable = Type.Object({
   method: Type.Literal("POST"),
   path: Type.Literal("/plugins/{name}/disable"),
   parameters: Type.Object({
-    query: Type.Object({
-      force: Type.Boolean(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        force: Type.Boolean(),
+      }),
+    ),
     path: Type.Object({
       name: Type.String(),
     }),
@@ -2970,9 +3020,11 @@ export const post_PluginUpgrade = Type.Object({
     path: Type.Object({
       name: Type.String(),
     }),
-    header: Type.Object({
-      "X-Registry-Auth": Type.String(),
-    }),
+    header: Type.Partial(
+      Type.Object({
+        "X-Registry-Auth": Type.String(),
+      }),
+    ),
   }),
   response: Type.Unknown(),
 });
@@ -3044,9 +3096,11 @@ export const delete_NodeDelete = Type.Object({
   method: Type.Literal("DELETE"),
   path: Type.Literal("/nodes/{id}"),
   parameters: Type.Object({
-    query: Type.Object({
-      force: Type.Boolean(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        force: Type.Boolean(),
+      }),
+    ),
     path: Type.Object({
       id: Type.String(),
     }),
@@ -3162,9 +3216,11 @@ export const post_ServiceCreate = Type.Object({
   method: Type.Literal("POST"),
   path: Type.Literal("/services/create"),
   parameters: Type.Object({
-    header: Type.Object({
-      "X-Registry-Auth": Type.String(),
-    }),
+    header: Type.Partial(
+      Type.Object({
+        "X-Registry-Auth": Type.String(),
+      }),
+    ),
   }),
   response: Type.Partial(
     Type.Object({
@@ -3179,9 +3235,11 @@ export const get_ServiceInspect = Type.Object({
   method: Type.Literal("GET"),
   path: Type.Literal("/services/{id}"),
   parameters: Type.Object({
-    query: Type.Object({
-      insertDefaults: Type.Boolean(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        insertDefaults: Type.Boolean(),
+      }),
+    ),
     path: Type.Object({
       id: Type.String(),
     }),
@@ -3214,9 +3272,11 @@ export const post_ServiceUpdate = Type.Object({
     path: Type.Object({
       id: Type.String(),
     }),
-    header: Type.Object({
-      "X-Registry-Auth": Type.String(),
-    }),
+    header: Type.Partial(
+      Type.Object({
+        "X-Registry-Auth": Type.String(),
+      }),
+    ),
   }),
   response: ServiceUpdateResponse,
 });
@@ -3226,15 +3286,17 @@ export const get_ServiceLogs = Type.Object({
   method: Type.Literal("GET"),
   path: Type.Literal("/services/{id}/logs"),
   parameters: Type.Object({
-    query: Type.Object({
-      details: Type.Boolean(),
-      follow: Type.Boolean(),
-      stdout: Type.Boolean(),
-      stderr: Type.Boolean(),
-      since: Type.Number(),
-      timestamps: Type.Boolean(),
-      tail: Type.String(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        details: Type.Boolean(),
+        follow: Type.Boolean(),
+        stdout: Type.Boolean(),
+        stderr: Type.Boolean(),
+        since: Type.Number(),
+        timestamps: Type.Boolean(),
+        tail: Type.String(),
+      }),
+    ),
     path: Type.Object({
       id: Type.String(),
     }),
@@ -3273,15 +3335,17 @@ export const get_TaskLogs = Type.Object({
   method: Type.Literal("GET"),
   path: Type.Literal("/tasks/{id}/logs"),
   parameters: Type.Object({
-    query: Type.Object({
-      details: Type.Boolean(),
-      follow: Type.Boolean(),
-      stdout: Type.Boolean(),
-      stderr: Type.Boolean(),
-      since: Type.Number(),
-      timestamps: Type.Boolean(),
-      tail: Type.String(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        details: Type.Boolean(),
+        follow: Type.Boolean(),
+        stdout: Type.Boolean(),
+        stderr: Type.Boolean(),
+        since: Type.Number(),
+        timestamps: Type.Boolean(),
+        tail: Type.String(),
+      }),
+    ),
     path: Type.Object({
       id: Type.String(),
     }),

--- a/packages/typed-openapi/tests/snapshots/docker.openapi.valibot.ts
+++ b/packages/typed-openapi/tests/snapshots/docker.openapi.valibot.ts
@@ -1680,7 +1680,7 @@ export const get_ContainerInspect = v.object({
   path: v.literal("/containers/{id}/json"),
   parameters: v.object({
     query: v.object({
-      size: v.boolean(),
+      size: v.optional(v.boolean()),
     }),
     path: v.object({
       id: v.string(),
@@ -1721,7 +1721,7 @@ export const get_ContainerTop = v.object({
   path: v.literal("/containers/{id}/top"),
   parameters: v.object({
     query: v.object({
-      ps_args: v.string(),
+      ps_args: v.optional(v.string()),
     }),
     path: v.object({
       id: v.string(),
@@ -1739,13 +1739,13 @@ export const get_ContainerLogs = v.object({
   path: v.literal("/containers/{id}/logs"),
   parameters: v.object({
     query: v.object({
-      follow: v.boolean(),
-      stdout: v.boolean(),
-      stderr: v.boolean(),
-      since: v.number(),
-      until: v.number(),
-      timestamps: v.boolean(),
-      tail: v.string(),
+      follow: v.optional(v.boolean()),
+      stdout: v.optional(v.boolean()),
+      stderr: v.optional(v.boolean()),
+      since: v.optional(v.number()),
+      until: v.optional(v.number()),
+      timestamps: v.optional(v.boolean()),
+      tail: v.optional(v.string()),
     }),
     path: v.object({
       id: v.string(),
@@ -1784,8 +1784,8 @@ export const get_ContainerStats = v.object({
   path: v.literal("/containers/{id}/stats"),
   parameters: v.object({
     query: v.object({
-      stream: v.boolean(),
-      "one-shot": v.boolean(),
+      stream: v.optional(v.boolean()),
+      "one-shot": v.optional(v.boolean()),
     }),
     path: v.object({
       id: v.string(),
@@ -1800,8 +1800,8 @@ export const post_ContainerResize = v.object({
   path: v.literal("/containers/{id}/resize"),
   parameters: v.object({
     query: v.object({
-      h: v.number(),
-      w: v.number(),
+      h: v.optional(v.number()),
+      w: v.optional(v.number()),
     }),
     path: v.object({
       id: v.string(),
@@ -1816,7 +1816,7 @@ export const post_ContainerStart = v.object({
   path: v.literal("/containers/{id}/start"),
   parameters: v.object({
     query: v.object({
-      detachKeys: v.string(),
+      detachKeys: v.optional(v.string()),
     }),
     path: v.object({
       id: v.string(),
@@ -1831,8 +1831,8 @@ export const post_ContainerStop = v.object({
   path: v.literal("/containers/{id}/stop"),
   parameters: v.object({
     query: v.object({
-      signal: v.string(),
-      t: v.number(),
+      signal: v.optional(v.string()),
+      t: v.optional(v.number()),
     }),
     path: v.object({
       id: v.string(),
@@ -1847,8 +1847,8 @@ export const post_ContainerRestart = v.object({
   path: v.literal("/containers/{id}/restart"),
   parameters: v.object({
     query: v.object({
-      signal: v.string(),
-      t: v.number(),
+      signal: v.optional(v.string()),
+      t: v.optional(v.number()),
     }),
     path: v.object({
       id: v.string(),
@@ -1863,7 +1863,7 @@ export const post_ContainerKill = v.object({
   path: v.literal("/containers/{id}/kill"),
   parameters: v.object({
     query: v.object({
-      signal: v.string(),
+      signal: v.optional(v.string()),
     }),
     path: v.object({
       id: v.string(),
@@ -1931,12 +1931,12 @@ export const post_ContainerAttach = v.object({
   path: v.literal("/containers/{id}/attach"),
   parameters: v.object({
     query: v.object({
-      detachKeys: v.string(),
-      logs: v.boolean(),
-      stream: v.boolean(),
-      stdin: v.boolean(),
-      stdout: v.boolean(),
-      stderr: v.boolean(),
+      detachKeys: v.optional(v.string()),
+      logs: v.optional(v.boolean()),
+      stream: v.optional(v.boolean()),
+      stdin: v.optional(v.boolean()),
+      stdout: v.optional(v.boolean()),
+      stderr: v.optional(v.boolean()),
     }),
     path: v.object({
       id: v.string(),
@@ -1951,12 +1951,12 @@ export const get_ContainerAttachWebsocket = v.object({
   path: v.literal("/containers/{id}/attach/ws"),
   parameters: v.object({
     query: v.object({
-      detachKeys: v.string(),
-      logs: v.boolean(),
-      stream: v.boolean(),
-      stdin: v.boolean(),
-      stdout: v.boolean(),
-      stderr: v.boolean(),
+      detachKeys: v.optional(v.string()),
+      logs: v.optional(v.boolean()),
+      stream: v.optional(v.boolean()),
+      stdin: v.optional(v.boolean()),
+      stdout: v.optional(v.boolean()),
+      stderr: v.optional(v.boolean()),
     }),
     path: v.object({
       id: v.string(),
@@ -1971,7 +1971,7 @@ export const post_ContainerWait = v.object({
   path: v.literal("/containers/{id}/wait"),
   parameters: v.object({
     query: v.object({
-      condition: v.union([v.literal("not-running"), v.literal("next-exit"), v.literal("removed")]),
+      condition: v.optional(v.union([v.literal("not-running"), v.literal("next-exit"), v.literal("removed")])),
     }),
     path: v.object({
       id: v.string(),
@@ -1986,9 +1986,9 @@ export const delete_ContainerDelete = v.object({
   path: v.literal("/containers/{id}"),
   parameters: v.object({
     query: v.object({
-      v: v.boolean(),
-      force: v.boolean(),
-      link: v.boolean(),
+      v: v.optional(v.boolean()),
+      force: v.optional(v.boolean()),
+      link: v.optional(v.boolean()),
     }),
     path: v.object({
       id: v.string(),
@@ -2106,8 +2106,8 @@ export const post_ImageBuild = v.object({
       outputs: v.optional(v.string()),
     }),
     header: v.object({
-      "Content-type": v.literal("application/x-tar"),
-      "X-Registry-Config": v.string(),
+      "Content-type": v.optional(v.literal("application/x-tar")),
+      "X-Registry-Config": v.optional(v.string()),
     }),
   }),
   response: v.unknown(),
@@ -2145,7 +2145,7 @@ export const post_ImageCreate = v.object({
       platform: v.optional(v.string()),
     }),
     header: v.object({
-      "X-Registry-Auth": v.string(),
+      "X-Registry-Auth": v.optional(v.string()),
     }),
   }),
   response: v.unknown(),
@@ -2190,7 +2190,7 @@ export const post_ImagePush = v.object({
   path: v.literal("/images/{name}/push"),
   parameters: v.object({
     query: v.object({
-      tag: v.string(),
+      tag: v.optional(v.string()),
     }),
     path: v.object({
       name: v.string(),
@@ -2208,8 +2208,8 @@ export const post_ImageTag = v.object({
   path: v.literal("/images/{name}/tag"),
   parameters: v.object({
     query: v.object({
-      repo: v.string(),
-      tag: v.string(),
+      repo: v.optional(v.string()),
+      tag: v.optional(v.string()),
     }),
     path: v.object({
       name: v.string(),
@@ -2224,8 +2224,8 @@ export const delete_ImageDelete = v.object({
   path: v.literal("/images/{name}"),
   parameters: v.object({
     query: v.object({
-      force: v.boolean(),
-      noprune: v.boolean(),
+      force: v.optional(v.boolean()),
+      noprune: v.optional(v.boolean()),
     }),
     path: v.object({
       name: v.string(),
@@ -2429,8 +2429,8 @@ export const post_ExecResize = v.object({
   path: v.literal("/exec/{id}/resize"),
   parameters: v.object({
     query: v.object({
-      h: v.number(),
-      w: v.number(),
+      h: v.optional(v.number()),
+      w: v.optional(v.number()),
     }),
     path: v.object({
       id: v.string(),
@@ -2516,7 +2516,7 @@ export const delete_VolumeDelete = v.object({
   path: v.literal("/volumes/{name}"),
   parameters: v.object({
     query: v.object({
-      force: v.boolean(),
+      force: v.optional(v.boolean()),
     }),
     path: v.object({
       name: v.string(),
@@ -2558,8 +2558,8 @@ export const get_NetworkInspect = v.object({
   path: v.literal("/networks/{id}"),
   parameters: v.object({
     query: v.object({
-      verbose: v.boolean(),
-      scope: v.string(),
+      verbose: v.optional(v.boolean()),
+      scope: v.optional(v.string()),
     }),
     path: v.object({
       id: v.string(),
@@ -2663,7 +2663,7 @@ export const post_PluginPull = v.object({
       name: v.string(),
     }),
     header: v.object({
-      "X-Registry-Auth": v.string(),
+      "X-Registry-Auth": v.optional(v.string()),
     }),
   }),
   response: v.unknown(),
@@ -2687,7 +2687,7 @@ export const delete_PluginDelete = v.object({
   path: v.literal("/plugins/{name}"),
   parameters: v.object({
     query: v.object({
-      force: v.boolean(),
+      force: v.optional(v.boolean()),
     }),
     path: v.object({
       name: v.string(),
@@ -2702,7 +2702,7 @@ export const post_PluginEnable = v.object({
   path: v.literal("/plugins/{name}/enable"),
   parameters: v.object({
     query: v.object({
-      timeout: v.number(),
+      timeout: v.optional(v.number()),
     }),
     path: v.object({
       name: v.string(),
@@ -2717,7 +2717,7 @@ export const post_PluginDisable = v.object({
   path: v.literal("/plugins/{name}/disable"),
   parameters: v.object({
     query: v.object({
-      force: v.boolean(),
+      force: v.optional(v.boolean()),
     }),
     path: v.object({
       name: v.string(),
@@ -2738,7 +2738,7 @@ export const post_PluginUpgrade = v.object({
       name: v.string(),
     }),
     header: v.object({
-      "X-Registry-Auth": v.string(),
+      "X-Registry-Auth": v.optional(v.string()),
     }),
   }),
   response: v.unknown(),
@@ -2810,7 +2810,7 @@ export const delete_NodeDelete = v.object({
   path: v.literal("/nodes/{id}"),
   parameters: v.object({
     query: v.object({
-      force: v.boolean(),
+      force: v.optional(v.boolean()),
     }),
     path: v.object({
       id: v.string(),
@@ -2922,7 +2922,7 @@ export const post_ServiceCreate = v.object({
   path: v.literal("/services/create"),
   parameters: v.object({
     header: v.object({
-      "X-Registry-Auth": v.string(),
+      "X-Registry-Auth": v.optional(v.string()),
     }),
   }),
   response: v.object({
@@ -2937,7 +2937,7 @@ export const get_ServiceInspect = v.object({
   path: v.literal("/services/{id}"),
   parameters: v.object({
     query: v.object({
-      insertDefaults: v.boolean(),
+      insertDefaults: v.optional(v.boolean()),
     }),
     path: v.object({
       id: v.string(),
@@ -2972,7 +2972,7 @@ export const post_ServiceUpdate = v.object({
       id: v.string(),
     }),
     header: v.object({
-      "X-Registry-Auth": v.string(),
+      "X-Registry-Auth": v.optional(v.string()),
     }),
   }),
   response: ServiceUpdateResponse,
@@ -2984,13 +2984,13 @@ export const get_ServiceLogs = v.object({
   path: v.literal("/services/{id}/logs"),
   parameters: v.object({
     query: v.object({
-      details: v.boolean(),
-      follow: v.boolean(),
-      stdout: v.boolean(),
-      stderr: v.boolean(),
-      since: v.number(),
-      timestamps: v.boolean(),
-      tail: v.string(),
+      details: v.optional(v.boolean()),
+      follow: v.optional(v.boolean()),
+      stdout: v.optional(v.boolean()),
+      stderr: v.optional(v.boolean()),
+      since: v.optional(v.number()),
+      timestamps: v.optional(v.boolean()),
+      tail: v.optional(v.string()),
     }),
     path: v.object({
       id: v.string(),
@@ -3029,13 +3029,13 @@ export const get_TaskLogs = v.object({
   path: v.literal("/tasks/{id}/logs"),
   parameters: v.object({
     query: v.object({
-      details: v.boolean(),
-      follow: v.boolean(),
-      stdout: v.boolean(),
-      stderr: v.boolean(),
-      since: v.number(),
-      timestamps: v.boolean(),
-      tail: v.string(),
+      details: v.optional(v.boolean()),
+      follow: v.optional(v.boolean()),
+      stdout: v.optional(v.boolean()),
+      stderr: v.optional(v.boolean()),
+      since: v.optional(v.number()),
+      timestamps: v.optional(v.boolean()),
+      tail: v.optional(v.string()),
     }),
     path: v.object({
       id: v.string(),

--- a/packages/typed-openapi/tests/snapshots/docker.openapi.yup.ts
+++ b/packages/typed-openapi/tests/snapshots/docker.openapi.yup.ts
@@ -2194,7 +2194,7 @@ export const get_ContainerInspect = {
   path: y.mixed((value): value is "/containers/{id}/json" => value === "/containers/{id}/json").required(),
   parameters: y.object({
     query: y.object({
-      size: y.boolean().required(),
+      size: y.boolean().required().optional(),
     }),
     path: y.object({
       id: y.string().required(),
@@ -2242,7 +2242,7 @@ export const get_ContainerTop = {
   path: y.mixed((value): value is "/containers/{id}/top" => value === "/containers/{id}/top").required(),
   parameters: y.object({
     query: y.object({
-      ps_args: y.string().required(),
+      ps_args: y.string().required().optional(),
     }),
     path: y.object({
       id: y.string().required(),
@@ -2260,13 +2260,13 @@ export const get_ContainerLogs = {
   path: y.mixed((value): value is "/containers/{id}/logs" => value === "/containers/{id}/logs").required(),
   parameters: y.object({
     query: y.object({
-      follow: y.boolean().required(),
-      stdout: y.boolean().required(),
-      stderr: y.boolean().required(),
-      since: y.number().required(),
-      until: y.number().required(),
-      timestamps: y.boolean().required(),
-      tail: y.string().required(),
+      follow: y.boolean().required().optional(),
+      stdout: y.boolean().required().optional(),
+      stderr: y.boolean().required().optional(),
+      since: y.number().required().optional(),
+      until: y.number().required().optional(),
+      timestamps: y.boolean().required().optional(),
+      tail: y.string().required().optional(),
     }),
     path: y.object({
       id: y.string().required(),
@@ -2305,8 +2305,8 @@ export const get_ContainerStats = {
   path: y.mixed((value): value is "/containers/{id}/stats" => value === "/containers/{id}/stats").required(),
   parameters: y.object({
     query: y.object({
-      stream: y.boolean().required(),
-      "one-shot": y.boolean().required(),
+      stream: y.boolean().required().optional(),
+      "one-shot": y.boolean().required().optional(),
     }),
     path: y.object({
       id: y.string().required(),
@@ -2321,8 +2321,8 @@ export const post_ContainerResize = {
   path: y.mixed((value): value is "/containers/{id}/resize" => value === "/containers/{id}/resize").required(),
   parameters: y.object({
     query: y.object({
-      h: y.number().required(),
-      w: y.number().required(),
+      h: y.number().required().optional(),
+      w: y.number().required().optional(),
     }),
     path: y.object({
       id: y.string().required(),
@@ -2337,7 +2337,7 @@ export const post_ContainerStart = {
   path: y.mixed((value): value is "/containers/{id}/start" => value === "/containers/{id}/start").required(),
   parameters: y.object({
     query: y.object({
-      detachKeys: y.string().required(),
+      detachKeys: y.string().required().optional(),
     }),
     path: y.object({
       id: y.string().required(),
@@ -2352,8 +2352,8 @@ export const post_ContainerStop = {
   path: y.mixed((value): value is "/containers/{id}/stop" => value === "/containers/{id}/stop").required(),
   parameters: y.object({
     query: y.object({
-      signal: y.string().required(),
-      t: y.number().required(),
+      signal: y.string().required().optional(),
+      t: y.number().required().optional(),
     }),
     path: y.object({
       id: y.string().required(),
@@ -2368,8 +2368,8 @@ export const post_ContainerRestart = {
   path: y.mixed((value): value is "/containers/{id}/restart" => value === "/containers/{id}/restart").required(),
   parameters: y.object({
     query: y.object({
-      signal: y.string().required(),
-      t: y.number().required(),
+      signal: y.string().required().optional(),
+      t: y.number().required().optional(),
     }),
     path: y.object({
       id: y.string().required(),
@@ -2384,7 +2384,7 @@ export const post_ContainerKill = {
   path: y.mixed((value): value is "/containers/{id}/kill" => value === "/containers/{id}/kill").required(),
   parameters: y.object({
     query: y.object({
-      signal: y.string().required(),
+      signal: y.string().required().optional(),
     }),
     path: y.object({
       id: y.string().required(),
@@ -2452,12 +2452,12 @@ export const post_ContainerAttach = {
   path: y.mixed((value): value is "/containers/{id}/attach" => value === "/containers/{id}/attach").required(),
   parameters: y.object({
     query: y.object({
-      detachKeys: y.string().required(),
-      logs: y.boolean().required(),
-      stream: y.boolean().required(),
-      stdin: y.boolean().required(),
-      stdout: y.boolean().required(),
-      stderr: y.boolean().required(),
+      detachKeys: y.string().required().optional(),
+      logs: y.boolean().required().optional(),
+      stream: y.boolean().required().optional(),
+      stdin: y.boolean().required().optional(),
+      stdout: y.boolean().required().optional(),
+      stderr: y.boolean().required().optional(),
     }),
     path: y.object({
       id: y.string().required(),
@@ -2472,12 +2472,12 @@ export const get_ContainerAttachWebsocket = {
   path: y.mixed((value): value is "/containers/{id}/attach/ws" => value === "/containers/{id}/attach/ws").required(),
   parameters: y.object({
     query: y.object({
-      detachKeys: y.string().required(),
-      logs: y.boolean().required(),
-      stream: y.boolean().required(),
-      stdin: y.boolean().required(),
-      stdout: y.boolean().required(),
-      stderr: y.boolean().required(),
+      detachKeys: y.string().required().optional(),
+      logs: y.boolean().required().optional(),
+      stream: y.boolean().required().optional(),
+      stdin: y.boolean().required().optional(),
+      stdout: y.boolean().required().optional(),
+      stderr: y.boolean().required().optional(),
     }),
     path: y.object({
       id: y.string().required(),
@@ -2499,7 +2499,8 @@ export const post_ContainerWait = {
           y.mixed((value): value is "next-exit" => value === "next-exit").required(),
           y.mixed((value): value is "removed" => value === "removed").required(),
         ])
-        .required(),
+        .required()
+        .optional(),
     }),
     path: y.object({
       id: y.string().required(),
@@ -2514,9 +2515,9 @@ export const delete_ContainerDelete = {
   path: y.mixed((value): value is "/containers/{id}" => value === "/containers/{id}").required(),
   parameters: y.object({
     query: y.object({
-      v: y.boolean().required(),
-      force: y.boolean().required(),
-      link: y.boolean().required(),
+      v: y.boolean().required().optional(),
+      force: y.boolean().required().optional(),
+      link: y.boolean().required().optional(),
     }),
     path: y.object({
       id: y.string().required(),
@@ -2634,8 +2635,11 @@ export const post_ImageBuild = {
       outputs: y.string().required().optional(),
     }),
     header: y.object({
-      "Content-type": y.mixed((value): value is "application/x-tar" => value === "application/x-tar").required(),
-      "X-Registry-Config": y.string().required(),
+      "Content-type": y
+        .mixed((value): value is "application/x-tar" => value === "application/x-tar")
+        .required()
+        .optional(),
+      "X-Registry-Config": y.string().required().optional(),
     }),
   }),
   response: y.mixed((value): value is any => true).required() as y.MixedSchema<unknown>,
@@ -2673,7 +2677,7 @@ export const post_ImageCreate = {
       platform: y.string().required().optional(),
     }),
     header: y.object({
-      "X-Registry-Auth": y.string().required(),
+      "X-Registry-Auth": y.string().required().optional(),
     }),
   }),
   response: y.mixed((value): value is any => true).required() as y.MixedSchema<unknown>,
@@ -2718,7 +2722,7 @@ export const post_ImagePush = {
   path: y.mixed((value): value is "/images/{name}/push" => value === "/images/{name}/push").required(),
   parameters: y.object({
     query: y.object({
-      tag: y.string().required(),
+      tag: y.string().required().optional(),
     }),
     path: y.object({
       name: y.string().required(),
@@ -2736,8 +2740,8 @@ export const post_ImageTag = {
   path: y.mixed((value): value is "/images/{name}/tag" => value === "/images/{name}/tag").required(),
   parameters: y.object({
     query: y.object({
-      repo: y.string().required(),
-      tag: y.string().required(),
+      repo: y.string().required().optional(),
+      tag: y.string().required().optional(),
     }),
     path: y.object({
       name: y.string().required(),
@@ -2752,8 +2756,8 @@ export const delete_ImageDelete = {
   path: y.mixed((value): value is "/images/{name}" => value === "/images/{name}").required(),
   parameters: y.object({
     query: y.object({
-      force: y.boolean().required(),
-      noprune: y.boolean().required(),
+      force: y.boolean().required().optional(),
+      noprune: y.boolean().required().optional(),
     }),
     path: y.object({
       name: y.string().required(),
@@ -2967,8 +2971,8 @@ export const post_ExecResize = {
   path: y.mixed((value): value is "/exec/{id}/resize" => value === "/exec/{id}/resize").required(),
   parameters: y.object({
     query: y.object({
-      h: y.number().required(),
-      w: y.number().required(),
+      h: y.number().required().optional(),
+      w: y.number().required().optional(),
     }),
     path: y.object({
       id: y.string().required(),
@@ -3054,7 +3058,7 @@ export const delete_VolumeDelete = {
   path: y.mixed((value): value is "/volumes/{name}" => value === "/volumes/{name}").required(),
   parameters: y.object({
     query: y.object({
-      force: y.boolean().required(),
+      force: y.boolean().required().optional(),
     }),
     path: y.object({
       name: y.string().required(),
@@ -3096,8 +3100,8 @@ export const get_NetworkInspect = {
   path: y.mixed((value): value is "/networks/{id}" => value === "/networks/{id}").required(),
   parameters: y.object({
     query: y.object({
-      verbose: y.boolean().required(),
-      scope: y.string().required(),
+      verbose: y.boolean().required().optional(),
+      scope: y.string().required().optional(),
     }),
     path: y.object({
       id: y.string().required(),
@@ -3201,7 +3205,7 @@ export const post_PluginPull = {
       name: y.string().required(),
     }),
     header: y.object({
-      "X-Registry-Auth": y.string().required(),
+      "X-Registry-Auth": y.string().required().optional(),
     }),
   }),
   response: y.mixed((value): value is any => true).required() as y.MixedSchema<unknown>,
@@ -3225,7 +3229,7 @@ export const delete_PluginDelete = {
   path: y.mixed((value): value is "/plugins/{name}" => value === "/plugins/{name}").required(),
   parameters: y.object({
     query: y.object({
-      force: y.boolean().required(),
+      force: y.boolean().required().optional(),
     }),
     path: y.object({
       name: y.string().required(),
@@ -3240,7 +3244,7 @@ export const post_PluginEnable = {
   path: y.mixed((value): value is "/plugins/{name}/enable" => value === "/plugins/{name}/enable").required(),
   parameters: y.object({
     query: y.object({
-      timeout: y.number().required(),
+      timeout: y.number().required().optional(),
     }),
     path: y.object({
       name: y.string().required(),
@@ -3255,7 +3259,7 @@ export const post_PluginDisable = {
   path: y.mixed((value): value is "/plugins/{name}/disable" => value === "/plugins/{name}/disable").required(),
   parameters: y.object({
     query: y.object({
-      force: y.boolean().required(),
+      force: y.boolean().required().optional(),
     }),
     path: y.object({
       name: y.string().required(),
@@ -3276,7 +3280,7 @@ export const post_PluginUpgrade = {
       name: y.string().required(),
     }),
     header: y.object({
-      "X-Registry-Auth": y.string().required(),
+      "X-Registry-Auth": y.string().required().optional(),
     }),
   }),
   response: y.mixed((value): value is any => true).required() as y.MixedSchema<unknown>,
@@ -3348,7 +3352,7 @@ export const delete_NodeDelete = {
   path: y.mixed((value): value is "/nodes/{id}" => value === "/nodes/{id}").required(),
   parameters: y.object({
     query: y.object({
-      force: y.boolean().required(),
+      force: y.boolean().required().optional(),
     }),
     path: y.object({
       id: y.string().required(),
@@ -3460,7 +3464,7 @@ export const post_ServiceCreate = {
   path: y.mixed((value): value is "/services/create" => value === "/services/create").required(),
   parameters: y.object({
     header: y.object({
-      "X-Registry-Auth": y.string().required(),
+      "X-Registry-Auth": y.string().required().optional(),
     }),
   }),
   response: y.object({
@@ -3475,7 +3479,7 @@ export const get_ServiceInspect = {
   path: y.mixed((value): value is "/services/{id}" => value === "/services/{id}").required(),
   parameters: y.object({
     query: y.object({
-      insertDefaults: y.boolean().required(),
+      insertDefaults: y.boolean().required().optional(),
     }),
     path: y.object({
       id: y.string().required(),
@@ -3516,7 +3520,7 @@ export const post_ServiceUpdate = {
       id: y.string().required(),
     }),
     header: y.object({
-      "X-Registry-Auth": y.string().required(),
+      "X-Registry-Auth": y.string().required().optional(),
     }),
   }),
   response: ServiceUpdateResponse,
@@ -3528,13 +3532,13 @@ export const get_ServiceLogs = {
   path: y.mixed((value): value is "/services/{id}/logs" => value === "/services/{id}/logs").required(),
   parameters: y.object({
     query: y.object({
-      details: y.boolean().required(),
-      follow: y.boolean().required(),
-      stdout: y.boolean().required(),
-      stderr: y.boolean().required(),
-      since: y.number().required(),
-      timestamps: y.boolean().required(),
-      tail: y.string().required(),
+      details: y.boolean().required().optional(),
+      follow: y.boolean().required().optional(),
+      stdout: y.boolean().required().optional(),
+      stderr: y.boolean().required().optional(),
+      since: y.number().required().optional(),
+      timestamps: y.boolean().required().optional(),
+      tail: y.string().required().optional(),
     }),
     path: y.object({
       id: y.string().required(),
@@ -3573,13 +3577,13 @@ export const get_TaskLogs = {
   path: y.mixed((value): value is "/tasks/{id}/logs" => value === "/tasks/{id}/logs").required(),
   parameters: y.object({
     query: y.object({
-      details: y.boolean().required(),
-      follow: y.boolean().required(),
-      stdout: y.boolean().required(),
-      stderr: y.boolean().required(),
-      since: y.number().required(),
-      timestamps: y.boolean().required(),
-      tail: y.string().required(),
+      details: y.boolean().required().optional(),
+      follow: y.boolean().required().optional(),
+      stdout: y.boolean().required().optional(),
+      stderr: y.boolean().required().optional(),
+      since: y.number().required().optional(),
+      timestamps: y.boolean().required().optional(),
+      tail: y.string().required().optional(),
     }),
     path: y.object({
       id: y.string().required(),

--- a/packages/typed-openapi/tests/snapshots/docker.openapi.zod.ts
+++ b/packages/typed-openapi/tests/snapshots/docker.openapi.zod.ts
@@ -1669,7 +1669,7 @@ export const get_ContainerInspect = {
   path: z.literal("/containers/{id}/json"),
   parameters: z.object({
     query: z.object({
-      size: z.boolean(),
+      size: z.boolean().optional(),
     }),
     path: z.object({
       id: z.string(),
@@ -1710,7 +1710,7 @@ export const get_ContainerTop = {
   path: z.literal("/containers/{id}/top"),
   parameters: z.object({
     query: z.object({
-      ps_args: z.string(),
+      ps_args: z.string().optional(),
     }),
     path: z.object({
       id: z.string(),
@@ -1728,13 +1728,13 @@ export const get_ContainerLogs = {
   path: z.literal("/containers/{id}/logs"),
   parameters: z.object({
     query: z.object({
-      follow: z.boolean(),
-      stdout: z.boolean(),
-      stderr: z.boolean(),
-      since: z.number(),
-      until: z.number(),
-      timestamps: z.boolean(),
-      tail: z.string(),
+      follow: z.boolean().optional(),
+      stdout: z.boolean().optional(),
+      stderr: z.boolean().optional(),
+      since: z.number().optional(),
+      until: z.number().optional(),
+      timestamps: z.boolean().optional(),
+      tail: z.string().optional(),
     }),
     path: z.object({
       id: z.string(),
@@ -1773,8 +1773,8 @@ export const get_ContainerStats = {
   path: z.literal("/containers/{id}/stats"),
   parameters: z.object({
     query: z.object({
-      stream: z.boolean(),
-      "one-shot": z.boolean(),
+      stream: z.boolean().optional(),
+      "one-shot": z.boolean().optional(),
     }),
     path: z.object({
       id: z.string(),
@@ -1789,8 +1789,8 @@ export const post_ContainerResize = {
   path: z.literal("/containers/{id}/resize"),
   parameters: z.object({
     query: z.object({
-      h: z.number(),
-      w: z.number(),
+      h: z.number().optional(),
+      w: z.number().optional(),
     }),
     path: z.object({
       id: z.string(),
@@ -1805,7 +1805,7 @@ export const post_ContainerStart = {
   path: z.literal("/containers/{id}/start"),
   parameters: z.object({
     query: z.object({
-      detachKeys: z.string(),
+      detachKeys: z.string().optional(),
     }),
     path: z.object({
       id: z.string(),
@@ -1820,8 +1820,8 @@ export const post_ContainerStop = {
   path: z.literal("/containers/{id}/stop"),
   parameters: z.object({
     query: z.object({
-      signal: z.string(),
-      t: z.number(),
+      signal: z.string().optional(),
+      t: z.number().optional(),
     }),
     path: z.object({
       id: z.string(),
@@ -1836,8 +1836,8 @@ export const post_ContainerRestart = {
   path: z.literal("/containers/{id}/restart"),
   parameters: z.object({
     query: z.object({
-      signal: z.string(),
-      t: z.number(),
+      signal: z.string().optional(),
+      t: z.number().optional(),
     }),
     path: z.object({
       id: z.string(),
@@ -1852,7 +1852,7 @@ export const post_ContainerKill = {
   path: z.literal("/containers/{id}/kill"),
   parameters: z.object({
     query: z.object({
-      signal: z.string(),
+      signal: z.string().optional(),
     }),
     path: z.object({
       id: z.string(),
@@ -1920,12 +1920,12 @@ export const post_ContainerAttach = {
   path: z.literal("/containers/{id}/attach"),
   parameters: z.object({
     query: z.object({
-      detachKeys: z.string(),
-      logs: z.boolean(),
-      stream: z.boolean(),
-      stdin: z.boolean(),
-      stdout: z.boolean(),
-      stderr: z.boolean(),
+      detachKeys: z.string().optional(),
+      logs: z.boolean().optional(),
+      stream: z.boolean().optional(),
+      stdin: z.boolean().optional(),
+      stdout: z.boolean().optional(),
+      stderr: z.boolean().optional(),
     }),
     path: z.object({
       id: z.string(),
@@ -1940,12 +1940,12 @@ export const get_ContainerAttachWebsocket = {
   path: z.literal("/containers/{id}/attach/ws"),
   parameters: z.object({
     query: z.object({
-      detachKeys: z.string(),
-      logs: z.boolean(),
-      stream: z.boolean(),
-      stdin: z.boolean(),
-      stdout: z.boolean(),
-      stderr: z.boolean(),
+      detachKeys: z.string().optional(),
+      logs: z.boolean().optional(),
+      stream: z.boolean().optional(),
+      stdin: z.boolean().optional(),
+      stdout: z.boolean().optional(),
+      stderr: z.boolean().optional(),
     }),
     path: z.object({
       id: z.string(),
@@ -1960,7 +1960,7 @@ export const post_ContainerWait = {
   path: z.literal("/containers/{id}/wait"),
   parameters: z.object({
     query: z.object({
-      condition: z.union([z.literal("not-running"), z.literal("next-exit"), z.literal("removed")]),
+      condition: z.union([z.literal("not-running"), z.literal("next-exit"), z.literal("removed")]).optional(),
     }),
     path: z.object({
       id: z.string(),
@@ -1975,9 +1975,9 @@ export const delete_ContainerDelete = {
   path: z.literal("/containers/{id}"),
   parameters: z.object({
     query: z.object({
-      v: z.boolean(),
-      force: z.boolean(),
-      link: z.boolean(),
+      v: z.boolean().optional(),
+      force: z.boolean().optional(),
+      link: z.boolean().optional(),
     }),
     path: z.object({
       id: z.string(),
@@ -2095,8 +2095,8 @@ export const post_ImageBuild = {
       outputs: z.string().optional(),
     }),
     header: z.object({
-      "Content-type": z.literal("application/x-tar"),
-      "X-Registry-Config": z.string(),
+      "Content-type": z.literal("application/x-tar").optional(),
+      "X-Registry-Config": z.string().optional(),
     }),
   }),
   response: z.unknown(),
@@ -2134,7 +2134,7 @@ export const post_ImageCreate = {
       platform: z.string().optional(),
     }),
     header: z.object({
-      "X-Registry-Auth": z.string(),
+      "X-Registry-Auth": z.string().optional(),
     }),
   }),
   response: z.unknown(),
@@ -2179,7 +2179,7 @@ export const post_ImagePush = {
   path: z.literal("/images/{name}/push"),
   parameters: z.object({
     query: z.object({
-      tag: z.string(),
+      tag: z.string().optional(),
     }),
     path: z.object({
       name: z.string(),
@@ -2197,8 +2197,8 @@ export const post_ImageTag = {
   path: z.literal("/images/{name}/tag"),
   parameters: z.object({
     query: z.object({
-      repo: z.string(),
-      tag: z.string(),
+      repo: z.string().optional(),
+      tag: z.string().optional(),
     }),
     path: z.object({
       name: z.string(),
@@ -2213,8 +2213,8 @@ export const delete_ImageDelete = {
   path: z.literal("/images/{name}"),
   parameters: z.object({
     query: z.object({
-      force: z.boolean(),
-      noprune: z.boolean(),
+      force: z.boolean().optional(),
+      noprune: z.boolean().optional(),
     }),
     path: z.object({
       name: z.string(),
@@ -2418,8 +2418,8 @@ export const post_ExecResize = {
   path: z.literal("/exec/{id}/resize"),
   parameters: z.object({
     query: z.object({
-      h: z.number(),
-      w: z.number(),
+      h: z.number().optional(),
+      w: z.number().optional(),
     }),
     path: z.object({
       id: z.string(),
@@ -2505,7 +2505,7 @@ export const delete_VolumeDelete = {
   path: z.literal("/volumes/{name}"),
   parameters: z.object({
     query: z.object({
-      force: z.boolean(),
+      force: z.boolean().optional(),
     }),
     path: z.object({
       name: z.string(),
@@ -2547,8 +2547,8 @@ export const get_NetworkInspect = {
   path: z.literal("/networks/{id}"),
   parameters: z.object({
     query: z.object({
-      verbose: z.boolean(),
-      scope: z.string(),
+      verbose: z.boolean().optional(),
+      scope: z.string().optional(),
     }),
     path: z.object({
       id: z.string(),
@@ -2652,7 +2652,7 @@ export const post_PluginPull = {
       name: z.string(),
     }),
     header: z.object({
-      "X-Registry-Auth": z.string(),
+      "X-Registry-Auth": z.string().optional(),
     }),
   }),
   response: z.unknown(),
@@ -2676,7 +2676,7 @@ export const delete_PluginDelete = {
   path: z.literal("/plugins/{name}"),
   parameters: z.object({
     query: z.object({
-      force: z.boolean(),
+      force: z.boolean().optional(),
     }),
     path: z.object({
       name: z.string(),
@@ -2691,7 +2691,7 @@ export const post_PluginEnable = {
   path: z.literal("/plugins/{name}/enable"),
   parameters: z.object({
     query: z.object({
-      timeout: z.number(),
+      timeout: z.number().optional(),
     }),
     path: z.object({
       name: z.string(),
@@ -2706,7 +2706,7 @@ export const post_PluginDisable = {
   path: z.literal("/plugins/{name}/disable"),
   parameters: z.object({
     query: z.object({
-      force: z.boolean(),
+      force: z.boolean().optional(),
     }),
     path: z.object({
       name: z.string(),
@@ -2727,7 +2727,7 @@ export const post_PluginUpgrade = {
       name: z.string(),
     }),
     header: z.object({
-      "X-Registry-Auth": z.string(),
+      "X-Registry-Auth": z.string().optional(),
     }),
   }),
   response: z.unknown(),
@@ -2799,7 +2799,7 @@ export const delete_NodeDelete = {
   path: z.literal("/nodes/{id}"),
   parameters: z.object({
     query: z.object({
-      force: z.boolean(),
+      force: z.boolean().optional(),
     }),
     path: z.object({
       id: z.string(),
@@ -2911,7 +2911,7 @@ export const post_ServiceCreate = {
   path: z.literal("/services/create"),
   parameters: z.object({
     header: z.object({
-      "X-Registry-Auth": z.string(),
+      "X-Registry-Auth": z.string().optional(),
     }),
   }),
   response: z.object({
@@ -2926,7 +2926,7 @@ export const get_ServiceInspect = {
   path: z.literal("/services/{id}"),
   parameters: z.object({
     query: z.object({
-      insertDefaults: z.boolean(),
+      insertDefaults: z.boolean().optional(),
     }),
     path: z.object({
       id: z.string(),
@@ -2961,7 +2961,7 @@ export const post_ServiceUpdate = {
       id: z.string(),
     }),
     header: z.object({
-      "X-Registry-Auth": z.string(),
+      "X-Registry-Auth": z.string().optional(),
     }),
   }),
   response: ServiceUpdateResponse,
@@ -2973,13 +2973,13 @@ export const get_ServiceLogs = {
   path: z.literal("/services/{id}/logs"),
   parameters: z.object({
     query: z.object({
-      details: z.boolean(),
-      follow: z.boolean(),
-      stdout: z.boolean(),
-      stderr: z.boolean(),
-      since: z.number(),
-      timestamps: z.boolean(),
-      tail: z.string(),
+      details: z.boolean().optional(),
+      follow: z.boolean().optional(),
+      stdout: z.boolean().optional(),
+      stderr: z.boolean().optional(),
+      since: z.number().optional(),
+      timestamps: z.boolean().optional(),
+      tail: z.string().optional(),
     }),
     path: z.object({
       id: z.string(),
@@ -3018,13 +3018,13 @@ export const get_TaskLogs = {
   path: z.literal("/tasks/{id}/logs"),
   parameters: z.object({
     query: z.object({
-      details: z.boolean(),
-      follow: z.boolean(),
-      stdout: z.boolean(),
-      stderr: z.boolean(),
-      since: z.number(),
-      timestamps: z.boolean(),
-      tail: z.string(),
+      details: z.boolean().optional(),
+      follow: z.boolean().optional(),
+      stdout: z.boolean().optional(),
+      stderr: z.boolean().optional(),
+      since: z.number().optional(),
+      timestamps: z.boolean().optional(),
+      tail: z.string().optional(),
     }),
     path: z.object({
       id: z.string(),

--- a/packages/typed-openapi/tests/snapshots/petstore.arktype.ts
+++ b/packages/typed-openapi/tests/snapshots/petstore.arktype.ts
@@ -99,8 +99,8 @@ export const types = scope({
     path: '"/pet/{petId}"',
     parameters: {
       query: {
-        name: "string",
-        status: "string",
+        "name?": "string",
+        "status?": "string",
       },
       path: {
         petId: "number",
@@ -116,7 +116,7 @@ export const types = scope({
         petId: "number",
       },
       header: {
-        api_key: "string",
+        "api_key?": "string",
       },
     },
     response: "unknown",
@@ -126,7 +126,7 @@ export const types = scope({
     path: '"/pet/{petId}/uploadImage"',
     parameters: {
       query: {
-        additionalMetadata: "string",
+        "additionalMetadata?": "string",
       },
       path: {
         petId: "number",

--- a/packages/typed-openapi/tests/snapshots/petstore.client.ts
+++ b/packages/typed-openapi/tests/snapshots/petstore.client.ts
@@ -78,7 +78,7 @@ export namespace Endpoints {
     method: "POST";
     path: "/pet/{petId}";
     parameters: {
-      query: { name: string; status: string };
+      query: Partial<{ name: string; status: string }>;
       path: { petId: number };
     };
     response: unknown;
@@ -88,7 +88,7 @@ export namespace Endpoints {
     path: "/pet/{petId}";
     parameters: {
       path: { petId: number };
-      header: { api_key: string };
+      header: Partial<{ api_key: string }>;
     };
     response: unknown;
   };
@@ -96,7 +96,7 @@ export namespace Endpoints {
     method: "POST";
     path: "/pet/{petId}/uploadImage";
     parameters: {
-      query: { additionalMetadata: string };
+      query: Partial<{ additionalMetadata: string }>;
       path: { petId: number };
     };
     response: Schemas.ApiResponse;

--- a/packages/typed-openapi/tests/snapshots/petstore.io-ts.ts
+++ b/packages/typed-openapi/tests/snapshots/petstore.io-ts.ts
@@ -130,8 +130,8 @@ export const post_UpdatePetWithForm = t.type({
   path: t.literal("/pet/{petId}"),
   parameters: t.type({
     query: t.type({
-      name: t.string,
-      status: t.string,
+      name: t.union([t.undefined, t.string]),
+      status: t.union([t.undefined, t.string]),
     }),
     path: t.type({
       petId: t.number,
@@ -149,7 +149,7 @@ export const delete_DeletePet = t.type({
       petId: t.number,
     }),
     header: t.type({
-      api_key: t.string,
+      api_key: t.union([t.undefined, t.string]),
     }),
   }),
   response: t.unknown,
@@ -161,7 +161,7 @@ export const post_UploadFile = t.type({
   path: t.literal("/pet/{petId}/uploadImage"),
   parameters: t.type({
     query: t.type({
-      additionalMetadata: t.string,
+      additionalMetadata: t.union([t.undefined, t.string]),
     }),
     path: t.type({
       petId: t.number,

--- a/packages/typed-openapi/tests/snapshots/petstore.typebox.ts
+++ b/packages/typed-openapi/tests/snapshots/petstore.typebox.ts
@@ -146,10 +146,12 @@ export const post_UpdatePetWithForm = Type.Object({
   method: Type.Literal("POST"),
   path: Type.Literal("/pet/{petId}"),
   parameters: Type.Object({
-    query: Type.Object({
-      name: Type.String(),
-      status: Type.String(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        name: Type.String(),
+        status: Type.String(),
+      }),
+    ),
     path: Type.Object({
       petId: Type.Number(),
     }),
@@ -165,9 +167,11 @@ export const delete_DeletePet = Type.Object({
     path: Type.Object({
       petId: Type.Number(),
     }),
-    header: Type.Object({
-      api_key: Type.String(),
-    }),
+    header: Type.Partial(
+      Type.Object({
+        api_key: Type.String(),
+      }),
+    ),
   }),
   response: Type.Unknown(),
 });
@@ -177,9 +181,11 @@ export const post_UploadFile = Type.Object({
   method: Type.Literal("POST"),
   path: Type.Literal("/pet/{petId}/uploadImage"),
   parameters: Type.Object({
-    query: Type.Object({
-      additionalMetadata: Type.String(),
-    }),
+    query: Type.Partial(
+      Type.Object({
+        additionalMetadata: Type.String(),
+      }),
+    ),
     path: Type.Object({
       petId: Type.Number(),
     }),

--- a/packages/typed-openapi/tests/snapshots/petstore.valibot.ts
+++ b/packages/typed-openapi/tests/snapshots/petstore.valibot.ts
@@ -129,8 +129,8 @@ export const post_UpdatePetWithForm = v.object({
   path: v.literal("/pet/{petId}"),
   parameters: v.object({
     query: v.object({
-      name: v.string(),
-      status: v.string(),
+      name: v.optional(v.string()),
+      status: v.optional(v.string()),
     }),
     path: v.object({
       petId: v.number(),
@@ -148,7 +148,7 @@ export const delete_DeletePet = v.object({
       petId: v.number(),
     }),
     header: v.object({
-      api_key: v.string(),
+      api_key: v.optional(v.string()),
     }),
   }),
   response: v.unknown(),
@@ -160,7 +160,7 @@ export const post_UploadFile = v.object({
   path: v.literal("/pet/{petId}/uploadImage"),
   parameters: v.object({
     query: v.object({
-      additionalMetadata: v.string(),
+      additionalMetadata: v.optional(v.string()),
     }),
     path: v.object({
       petId: v.number(),

--- a/packages/typed-openapi/tests/snapshots/petstore.yup.ts
+++ b/packages/typed-openapi/tests/snapshots/petstore.yup.ts
@@ -161,8 +161,8 @@ export const post_UpdatePetWithForm = {
   path: y.mixed((value): value is "/pet/{petId}" => value === "/pet/{petId}").required(),
   parameters: y.object({
     query: y.object({
-      name: y.string().required(),
-      status: y.string().required(),
+      name: y.string().required().optional(),
+      status: y.string().required().optional(),
     }),
     path: y.object({
       petId: y.number().required(),
@@ -180,7 +180,7 @@ export const delete_DeletePet = {
       petId: y.number().required(),
     }),
     header: y.object({
-      api_key: y.string().required(),
+      api_key: y.string().required().optional(),
     }),
   }),
   response: y.mixed((value): value is any => true).required() as y.MixedSchema<unknown>,
@@ -192,7 +192,7 @@ export const post_UploadFile = {
   path: y.mixed((value): value is "/pet/{petId}/uploadImage" => value === "/pet/{petId}/uploadImage").required(),
   parameters: y.object({
     query: y.object({
-      additionalMetadata: y.string().required(),
+      additionalMetadata: y.string().required().optional(),
     }),
     path: y.object({
       petId: y.number().required(),

--- a/packages/typed-openapi/tests/snapshots/petstore.zod.ts
+++ b/packages/typed-openapi/tests/snapshots/petstore.zod.ts
@@ -124,8 +124,8 @@ export const post_UpdatePetWithForm = {
   path: z.literal("/pet/{petId}"),
   parameters: z.object({
     query: z.object({
-      name: z.string(),
-      status: z.string(),
+      name: z.string().optional(),
+      status: z.string().optional(),
     }),
     path: z.object({
       petId: z.number(),
@@ -143,7 +143,7 @@ export const delete_DeletePet = {
       petId: z.number(),
     }),
     header: z.object({
-      api_key: z.string(),
+      api_key: z.string().optional(),
     }),
   }),
   response: z.unknown(),
@@ -155,7 +155,7 @@ export const post_UploadFile = {
   path: z.literal("/pet/{petId}/uploadImage"),
   parameters: z.object({
     query: z.object({
-      additionalMetadata: z.string(),
+      additionalMetadata: z.string().optional(),
     }),
     path: z.object({
       petId: z.number(),


### PR DESCRIPTION
Bug: 
When a path parameter is required but none of the query params are, the query params are not wrapped in a `Partial<>`.