### PR TITLE
Support path parameters

### DIFF
--- a/.changeset/tender-snakes-teach.md
+++ b/.changeset/tender-snakes-teach.md
@@ -1,0 +1,5 @@
+---
+"typed-openapi": minor
+---
+
+Support path parameters

--- a/packages/typed-openapi/src/map-openapi-endpoints.ts
+++ b/packages/typed-openapi/src/map-openapi-endpoints.ts
@@ -35,7 +35,7 @@ export const mapOpenApiEndpoints = (doc: OpenAPIObject) => {
 
       // Build a list of parameters by type + fill an object with all of them
       const lists = { query: [] as ParameterObject[], path: [] as ParameterObject[], header: [] as ParameterObject[] };
-      const paramObjects = (operation.parameters ?? []).reduce(
+      const paramObjects = [...(pathItemObj.parameters ?? []), ...(operation.parameters ?? [])].reduce(
         (acc, paramOrRef) => {
           const param = refs.unwrap(paramOrRef);
           const schema = openApiSchemaToTs({ schema: refs.unwrap(param.schema ?? {}), ctx });

--- a/packages/typed-openapi/tests/map-openapi-endpoints.test.ts
+++ b/packages/typed-openapi/tests/map-openapi-endpoints.test.ts
@@ -2612,4 +2612,56 @@ describe("map-openapi-endpoints", () => {
       }
     `);
   });
+
+  test("path and operation parameters", async ({ expect }) => {
+    const openApiDoc = (await SwaggerParser.parse("./tests/samples/parameters.yaml")) as OpenAPIObject;
+    expect(mapOpenApiEndpoints(openApiDoc).endpointList).toMatchInlineSnapshot(`
+      [
+        {
+          "meta": {
+            "alias": "get_UsersId",
+            "areParametersRequired": true,
+            "hasParameters": true,
+          },
+          "method": "get",
+          "operation": {
+            "parameters": [
+              {
+                "description": "If true, the endpoint returns only the user metadata.",
+                "in": "query",
+                "name": "metadata",
+                "required": false,
+                "schema": {
+                  "type": "boolean",
+                },
+              },
+            ],
+            "responses": {
+              "200": {
+                "description": "OK",
+              },
+            },
+            "summary": "Gets a user by ID",
+          },
+          "parameters": {
+            "path": {
+              "id": {
+                "type": "keyword",
+                "value": "number",
+              },
+            },
+            "query": {
+              "type": "ref",
+              "value": "Partial<{ metadata: boolean }>",
+            },
+          },
+          "path": "/users/{id}",
+          "response": {
+            "type": "keyword",
+            "value": "unknown",
+          },
+        },
+      ]
+    `);
+  });
 });

--- a/packages/typed-openapi/tests/samples/parameters.yaml
+++ b/packages/typed-openapi/tests/samples/parameters.yaml
@@ -1,0 +1,27 @@
+# https://swagger.io/docs/specification/describing-parameters/#common-for-path
+openapi: 3.0.3
+info:
+  title: Spec with both path-level and operation-level parameters
+paths:
+  /users/{id}:
+    parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+        description: The user ID.
+    # GET/users/{id}?metadata=true
+    get:
+      summary: Gets a user by ID
+      # Note we only define the query parameter, because the {id} is defined at the path level.
+      parameters:
+        - in: query
+          name: metadata
+          schema:
+            type: boolean
+          required: false
+          description: If true, the endpoint returns only the user metadata.
+      responses:
+        '200':
+          description: OK


### PR DESCRIPTION
Currently, parameters are only generated if they are defined on operations. But OpenAPI also supports defining parameters on paths. [Related documentation](https://swagger.io/docs/specification/describing-parameters/#common-for-path):

> ### Common Parameters for All Methods of a Path
>  Parameters shared by all operations of a path can be defined on the path level instead of the operation level. Path-level parameters are inherited by all operations of that path. A typical use case are the GET/PUT/PATCH/DELETE operations that manipulate a resource accessed via a path parameter. 

This PR adds support for generating types from path parameters (additionally to operation ones)