### PR TITLE
fix: default response should be used as a fallback

### DIFF
--- a/.changeset/silly-spiders-switch.md
+++ b/.changeset/silly-spiders-switch.md
@@ -1,0 +1,5 @@
+---
+"typed-openapi": minor
+---
+
+Fix default response behavior (only use "default" as a fallback)

--- a/packages/typed-openapi/src/map-openapi-endpoints.ts
+++ b/packages/typed-openapi/src/map-openapi-endpoints.ts
@@ -103,17 +103,16 @@ export const mapOpenApiEndpoints = (doc: OpenAPIObject) => {
         endpoint.parameters = Object.keys(params).length ? (params as any as EndpointParameters) : undefined;
       }
 
-      let responseObject;
-      // Match the default response or first 2xx-3xx response found
-      if (operation.responses.default) {
+      // Match the first 2xx-3xx response found, or fallback to default one otherwise
+      let responseObject: ResponseObject | undefined;
+      Object.entries(operation.responses).map(([status, responseOrRef]) => {
+        const statusCode = Number(status);
+        if (statusCode >= 200 && statusCode < 300) {
+          responseObject = refs.unwrap<ResponseObject>(responseOrRef);
+        }
+      });
+      if (!responseObject && operation.responses.default) {
         responseObject = refs.unwrap(operation.responses.default);
-      } else {
-        Object.entries(operation.responses).map(([status, responseOrRef]) => {
-          const statusCode = Number(status);
-          if (statusCode >= 200 && statusCode < 300) {
-            responseObject = refs.unwrap<ResponseObject>(responseOrRef);
-          }
-        });
       }
 
       const content = responseObject?.content;

--- a/packages/typed-openapi/tests/generator.test.ts
+++ b/packages/typed-openapi/tests/generator.test.ts
@@ -161,7 +161,7 @@ describe("generator", () => {
           parameters: {
             body: Array<User>;
           };
-          response: unknown;
+          response: Schemas.User;
         };
         export type get_LoginUser = {
           method: "GET";

--- a/packages/typed-openapi/tests/map-openapi-endpoints.test.ts
+++ b/packages/typed-openapi/tests/map-openapi-endpoints.test.ts
@@ -2196,8 +2196,8 @@ describe("map-openapi-endpoints", () => {
             },
             "path": "/user/createWithList",
             "response": {
-              "type": "keyword",
-              "value": "unknown",
+              "type": "ref",
+              "value": "User",
             },
           },
           {

--- a/packages/typed-openapi/tests/snapshots/petstore.arktype.ts
+++ b/packages/typed-openapi/tests/snapshots/petstore.arktype.ts
@@ -187,7 +187,7 @@ export const types = scope({
     parameters: {
       body: "User[]",
     },
-    response: "unknown",
+    response: "User",
   },
   get_LoginUser: {
     method: '"GET"',

--- a/packages/typed-openapi/tests/snapshots/petstore.client.ts
+++ b/packages/typed-openapi/tests/snapshots/petstore.client.ts
@@ -151,7 +151,7 @@ export namespace Endpoints {
     parameters: {
       body: Array<User>;
     };
-    response: unknown;
+    response: Schemas.User;
   };
   export type get_LoginUser = {
     method: "GET";

--- a/packages/typed-openapi/tests/snapshots/petstore.io-ts.ts
+++ b/packages/typed-openapi/tests/snapshots/petstore.io-ts.ts
@@ -234,7 +234,7 @@ export const post_CreateUsersWithListInput = t.type({
   parameters: t.type({
     body: t.array(User),
   }),
-  response: t.unknown,
+  response: User,
 });
 
 export type get_LoginUser = t.TypeOf<typeof get_LoginUser>;

--- a/packages/typed-openapi/tests/snapshots/petstore.typebox.ts
+++ b/packages/typed-openapi/tests/snapshots/petstore.typebox.ts
@@ -257,7 +257,7 @@ export const post_CreateUsersWithListInput = Type.Object({
   parameters: Type.Object({
     body: Type.Array(User),
   }),
-  response: Type.Unknown(),
+  response: User,
 });
 
 export type get_LoginUser = Static<typeof get_LoginUser>;

--- a/packages/typed-openapi/tests/snapshots/petstore.valibot.ts
+++ b/packages/typed-openapi/tests/snapshots/petstore.valibot.ts
@@ -233,7 +233,7 @@ export const post_CreateUsersWithListInput = v.object({
   parameters: v.object({
     body: v.array(User),
   }),
-  response: v.unknown(),
+  response: User,
 });
 
 export type get_LoginUser = v.Output<typeof get_LoginUser>;

--- a/packages/typed-openapi/tests/snapshots/petstore.yup.ts
+++ b/packages/typed-openapi/tests/snapshots/petstore.yup.ts
@@ -265,7 +265,7 @@ export const post_CreateUsersWithListInput = {
   parameters: y.object({
     body: y.array(User),
   }),
-  response: y.mixed((value): value is any => true).required() as y.MixedSchema<unknown>,
+  response: User,
 };
 
 export type get_LoginUser = typeof get_LoginUser;

--- a/packages/typed-openapi/tests/snapshots/petstore.zod.ts
+++ b/packages/typed-openapi/tests/snapshots/petstore.zod.ts
@@ -228,7 +228,7 @@ export const post_CreateUsersWithListInput = {
   parameters: z.object({
     body: z.array(User),
   }),
-  response: z.unknown(),
+  response: User,
 };
 
 export type get_LoginUser = typeof get_LoginUser;


### PR DESCRIPTION
Currently, the lib uses the "default" response when it exists, and only fallbacks on getting the first 2xx response otherwise. This behavior seems incorrect as "default" is intended to be a fallback for non-explciit responses [Documentation reference](https://swagger.io/docs/specification/describing-responses/#default):
> “Default” means this response is used for all HTTP codes that are not covered individually for this operation. 

Updated snapshots confirm the new behavior is correct 🙂 