### PR TITLE
fix: refer Schema namespace in generated body type

### DIFF
--- a/.changeset/bright-coins-exist.md
+++ b/.changeset/bright-coins-exist.md
@@ -1,0 +1,5 @@
+---
+"typed-openapi": patch
+---
+
+fix: refer Schema namespace in generated body type

--- a/packages/typed-openapi/tests/generator.test.ts
+++ b/packages/typed-openapi/tests/generator.test.ts
@@ -52,7 +52,7 @@ describe("generator", () => {
           method: "PUT";
           path: "/pet";
           parameters: {
-            body: Pet;
+            body: Schemas.Pet;
           };
           response: Schemas.Pet;
         };
@@ -60,7 +60,7 @@ describe("generator", () => {
           method: "POST";
           path: "/pet";
           parameters: {
-            body: Pet;
+            body: Schemas.Pet;
           };
           response: Schemas.Pet;
         };
@@ -127,7 +127,7 @@ describe("generator", () => {
           method: "POST";
           path: "/store/order";
           parameters: {
-            body: Order;
+            body: Schemas.Order;
           };
           response: Schemas.Order;
         };
@@ -151,7 +151,7 @@ describe("generator", () => {
           method: "POST";
           path: "/user";
           parameters: {
-            body: User;
+            body: Schemas.User;
           };
           response: Schemas.User;
         };
@@ -159,7 +159,7 @@ describe("generator", () => {
           method: "POST";
           path: "/user/createWithList";
           parameters: {
-            body: Array<User>;
+            body: Array<Schemas.User>;
           };
           response: unknown;
         };
@@ -191,7 +191,7 @@ describe("generator", () => {
           parameters: {
             path: { username: string };
 
-            body: User;
+            body: Schemas.User;
           };
           response: unknown;
         };

--- a/packages/typed-openapi/tests/snapshots/docker.openapi.client.ts
+++ b/packages/typed-openapi/tests/snapshots/docker.openapi.client.ts
@@ -864,7 +864,8 @@ export namespace Endpoints {
     parameters: {
       query: Partial<{ name: string; platform: string }>;
 
-      body: ContainerConfig & Partial<{ HostConfig: HostConfig; NetworkingConfig: NetworkingConfig }>;
+      body: Schemas.ContainerConfig &
+        Partial<{ HostConfig: Schemas.HostConfig; NetworkingConfig: Schemas.NetworkingConfig }>;
     };
     response: Schemas.ContainerCreateResponse;
   };
@@ -1005,7 +1006,7 @@ export namespace Endpoints {
     parameters: {
       path: { id: string };
 
-      body: Resources & Partial<{ RestartPolicy: RestartPolicy }>;
+      body: Schemas.Resources & Partial<{ RestartPolicy: Schemas.RestartPolicy }>;
     };
     response: Partial<{ Warnings: Array<string> }>;
   };
@@ -1265,7 +1266,7 @@ export namespace Endpoints {
     method: "POST";
     path: "/auth";
     parameters: {
-      body: AuthConfig;
+      body: Schemas.AuthConfig;
     };
     response: unknown;
   };
@@ -1307,7 +1308,7 @@ export namespace Endpoints {
         changes: string;
       }>;
 
-      body: ContainerConfig;
+      body: Schemas.ContainerConfig;
     };
     response: Schemas.IdResponse;
   };
@@ -1367,7 +1368,7 @@ export namespace Endpoints {
         AttachStdin: boolean;
         AttachStdout: boolean;
         AttachStderr: boolean;
-        ConsoleSize: Array<number> | null;
+        ConsoleSize: Array<number> | Schemas.null;
         DetachKeys: string;
         Tty: boolean;
         Env: Array<string>;
@@ -1385,7 +1386,7 @@ export namespace Endpoints {
     parameters: {
       path: { id: string };
 
-      body: Partial<{ Detach: boolean; Tty: boolean; ConsoleSize: Array<number> | null }>;
+      body: Partial<{ Detach: boolean; Tty: boolean; ConsoleSize: Array<number> | Schemas.null }>;
     };
     response: unknown;
   };
@@ -1430,7 +1431,7 @@ export namespace Endpoints {
     method: "POST";
     path: "/volumes/create";
     parameters: {
-      body: VolumeCreateOptions;
+      body: Schemas.VolumeCreateOptions;
     };
     response: Schemas.Volume;
   };
@@ -1449,7 +1450,7 @@ export namespace Endpoints {
       query: { version: number };
       path: { name: string };
 
-      body: Partial<{ Spec: ClusterVolumeSpec }>;
+      body: Partial<{ Spec: Schemas.ClusterVolumeSpec }>;
     };
     response: unknown;
   };
@@ -1506,7 +1507,7 @@ export namespace Endpoints {
         Internal?: boolean | undefined;
         Attachable?: boolean | undefined;
         Ingress?: boolean | undefined;
-        IPAM?: IPAM | undefined;
+        IPAM?: Schemas.IPAM | undefined;
         EnableIPv6?: boolean | undefined;
         Options?: unknown | undefined;
         Labels?: unknown | undefined;
@@ -1520,7 +1521,7 @@ export namespace Endpoints {
     parameters: {
       path: { id: string };
 
-      body: Partial<{ Container: string; EndpointConfig: EndpointSettings }>;
+      body: Partial<{ Container: string; EndpointConfig: Schemas.EndpointSettings }>;
     };
     response: unknown;
   };
@@ -1565,7 +1566,7 @@ export namespace Endpoints {
       query: { remote: string; name: string };
 
       header: Partial<{ "X-Registry-Auth": string }>;
-      body: Array<PluginPrivilege>;
+      body: Array<Schemas.PluginPrivilege>;
     };
     response: unknown;
   };
@@ -1611,7 +1612,7 @@ export namespace Endpoints {
       query: { remote: string };
       path: { name: string };
       header: Partial<{ "X-Registry-Auth": string }>;
-      body: Array<PluginPrivilege>;
+      body: Array<Schemas.PluginPrivilege>;
     };
     response: unknown;
   };
@@ -1673,7 +1674,7 @@ export namespace Endpoints {
       query: { version: number };
       path: { id: string };
 
-      body: NodeSpec;
+      body: Schemas.NodeSpec;
     };
     response: unknown;
   };
@@ -1695,7 +1696,7 @@ export namespace Endpoints {
         DefaultAddrPool: Array<string>;
         ForceNewCluster: boolean;
         SubnetSize: number;
-        Spec: SwarmSpec;
+        Spec: Schemas.SwarmSpec;
       }>;
     };
     response: string;
@@ -1733,7 +1734,7 @@ export namespace Endpoints {
         rotateManagerUnlockKey: boolean;
       };
 
-      body: SwarmSpec;
+      body: Schemas.SwarmSpec;
     };
     response: unknown;
   };
@@ -1764,7 +1765,7 @@ export namespace Endpoints {
     path: "/services/create";
     parameters: {
       header: Partial<{ "X-Registry-Auth": string }>;
-      body: ServiceSpec & unknown;
+      body: Schemas.ServiceSpec & unknown;
     };
     response: Partial<{ ID: string; Warning: string }>;
   };
@@ -1792,7 +1793,7 @@ export namespace Endpoints {
       query: { version: number; registryAuthFrom: "spec" | "previous-spec"; rollback: string };
       path: { id: string };
       header: Partial<{ "X-Registry-Auth": string }>;
-      body: ServiceSpec & unknown;
+      body: Schemas.ServiceSpec & unknown;
     };
     response: Schemas.ServiceUpdateResponse;
   };
@@ -1858,7 +1859,7 @@ export namespace Endpoints {
     method: "POST";
     path: "/secrets/create";
     parameters: {
-      body: SecretSpec & unknown;
+      body: Schemas.SecretSpec & unknown;
     };
     response: Schemas.IdResponse;
   };
@@ -1885,7 +1886,7 @@ export namespace Endpoints {
       query: { version: number };
       path: { id: string };
 
-      body: SecretSpec;
+      body: Schemas.SecretSpec;
     };
     response: unknown;
   };
@@ -1901,7 +1902,7 @@ export namespace Endpoints {
     method: "POST";
     path: "/configs/create";
     parameters: {
-      body: ConfigSpec & unknown;
+      body: Schemas.ConfigSpec & unknown;
     };
     response: Schemas.IdResponse;
   };
@@ -1928,7 +1929,7 @@ export namespace Endpoints {
       query: { version: number };
       path: { id: string };
 
-      body: ConfigSpec;
+      body: Schemas.ConfigSpec;
     };
     response: unknown;
   };

--- a/packages/typed-openapi/tests/snapshots/petstore.client.ts
+++ b/packages/typed-openapi/tests/snapshots/petstore.client.ts
@@ -42,7 +42,7 @@ export namespace Endpoints {
     method: "PUT";
     path: "/pet";
     parameters: {
-      body: Pet;
+      body: Schemas.Pet;
     };
     response: Schemas.Pet;
   };
@@ -50,7 +50,7 @@ export namespace Endpoints {
     method: "POST";
     path: "/pet";
     parameters: {
-      body: Pet;
+      body: Schemas.Pet;
     };
     response: Schemas.Pet;
   };
@@ -117,7 +117,7 @@ export namespace Endpoints {
     method: "POST";
     path: "/store/order";
     parameters: {
-      body: Order;
+      body: Schemas.Order;
     };
     response: Schemas.Order;
   };
@@ -141,7 +141,7 @@ export namespace Endpoints {
     method: "POST";
     path: "/user";
     parameters: {
-      body: User;
+      body: Schemas.User;
     };
     response: Schemas.User;
   };
@@ -149,7 +149,7 @@ export namespace Endpoints {
     method: "POST";
     path: "/user/createWithList";
     parameters: {
-      body: Array<User>;
+      body: Array<Schemas.User>;
     };
     response: unknown;
   };
@@ -181,7 +181,7 @@ export namespace Endpoints {
     parameters: {
       path: { username: string };
 
-      body: User;
+      body: Schemas.User;
     };
     response: unknown;
   };


### PR DESCRIPTION
Fix https://github.com/astahmer/typed-openapi/issues/11

Since https://github.com/astahmer/typed-openapi/pull/9, `body:` is accessible on endpoints. But these types references live under the `Schemas` namespace, which is not added in the `body:` type. IT results in a broken typescript file:

<img width="702" alt="Screenshot 2023-11-22 at 09 46 52" src="https://github.com/astahmer/typed-openapi/assets/674084/2544f178-f959-4fc3-9d60-5b39aeeb4cbb">

This PR ensures that we rely on the Schemas namespace to generate correct types:

<img width="658" alt="Screenshot 2023-11-22 at 09 47 24" src="https://github.com/astahmer/typed-openapi/assets/674084/6aebcc35-2dc0-4ced-8a24-3647b16cee3a">

Current test suite is enough to confirm the new behaviors works as expected and `.client.ts` files generated in tests are now correct
