### PR TITLE
Remove unused import to fix build

### DIFF
--- a/packages/typed-openapi/src/generator.ts
+++ b/packages/typed-openapi/src/generator.ts
@@ -2,7 +2,7 @@ import { capitalize, groupBy } from "pastable/server";
 import { Box } from "./box";
 import { prettify } from "./format";
 import { mapOpenApiEndpoints } from "./map-openapi-endpoints";
-import { AnyBox, AnyBoxDef, BoxRef } from "./types";
+import { AnyBox, AnyBoxDef } from "./types";
 import * as Codegen from "@sinclair/typebox-codegen";
 import { match } from "ts-pattern";
 import { type } from "arktype";


### PR DESCRIPTION
See error at build [here](https://github.com/astahmer/typed-openapi/actions/runs/6957915056/job/18931755368#step:6:5):

> Error: src/generator.ts(5,29): error TS6133: 'BoxRef' is declared but its value is never read.