### PR TITLE
zod-runtime: add typecast to ApiClient methods, fix #12

### DIFF
--- a/.changeset/fresh-actors-kiss.md
+++ b/.changeset/fresh-actors-kiss.md
@@ -1,0 +1,5 @@
+---
+"typed-openapi": minor
+---
+
+zod-runtime: add typecast in ApiClient methods to match the desired type

--- a/packages/typed-openapi/src/generator.ts
+++ b/packages/typed-openapi/src/generator.ts
@@ -293,7 +293,8 @@ export class ApiClient {
       .with("zod", "yup", () => infer(`TEndpoint["response"]`))
       .with("arktype", "io-ts", "typebox", "valibot", () => infer(`TEndpoint`) + `["response"]`)
       .otherwise(() => `TEndpoint["response"]`)}> {
-      return this.fetcher("${method}", this.baseUrl + path, params[0]);
+      return this.fetcher("${method}", this.baseUrl + path, params[0])${match(ctx.runtime)
+          .with("zod", () => `as Promise<TEndpoint["response"]> `).otherwise(() => ``)};
     }
     // </ApiClient.${method}>
     `

--- a/packages/typed-openapi/tests/snapshots/docker.openapi.zod.ts
+++ b/packages/typed-openapi/tests/snapshots/docker.openapi.zod.ts
@@ -3461,7 +3461,7 @@ export class ApiClient {
     path: Path,
     ...params: MaybeOptionalArg<z.infer<TEndpoint["parameters"]>>
   ): Promise<z.infer<TEndpoint["response"]>> {
-    return this.fetcher("get", this.baseUrl + path, params[0]);
+    return this.fetcher("get", this.baseUrl + path, params[0]) as Promise<TEndpoint["response"]>;
   }
   // </ApiClient.get>
 
@@ -3470,7 +3470,7 @@ export class ApiClient {
     path: Path,
     ...params: MaybeOptionalArg<z.infer<TEndpoint["parameters"]>>
   ): Promise<z.infer<TEndpoint["response"]>> {
-    return this.fetcher("post", this.baseUrl + path, params[0]);
+    return this.fetcher("post", this.baseUrl + path, params[0]) as Promise<TEndpoint["response"]>;
   }
   // </ApiClient.post>
 
@@ -3479,7 +3479,7 @@ export class ApiClient {
     path: Path,
     ...params: MaybeOptionalArg<z.infer<TEndpoint["parameters"]>>
   ): Promise<z.infer<TEndpoint["response"]>> {
-    return this.fetcher("delete", this.baseUrl + path, params[0]);
+    return this.fetcher("delete", this.baseUrl + path, params[0]) as Promise<TEndpoint["response"]>;
   }
   // </ApiClient.delete>
 
@@ -3488,7 +3488,7 @@ export class ApiClient {
     path: Path,
     ...params: MaybeOptionalArg<z.infer<TEndpoint["parameters"]>>
   ): Promise<z.infer<TEndpoint["response"]>> {
-    return this.fetcher("put", this.baseUrl + path, params[0]);
+    return this.fetcher("put", this.baseUrl + path, params[0]) as Promise<TEndpoint["response"]>;
   }
   // </ApiClient.put>
 
@@ -3497,7 +3497,7 @@ export class ApiClient {
     path: Path,
     ...params: MaybeOptionalArg<z.infer<TEndpoint["parameters"]>>
   ): Promise<z.infer<TEndpoint["response"]>> {
-    return this.fetcher("head", this.baseUrl + path, params[0]);
+    return this.fetcher("head", this.baseUrl + path, params[0]) as Promise<TEndpoint["response"]>;
   }
   // </ApiClient.head>
 }

--- a/packages/typed-openapi/tests/snapshots/petstore.zod.ts
+++ b/packages/typed-openapi/tests/snapshots/petstore.zod.ts
@@ -389,7 +389,7 @@ export class ApiClient {
     path: Path,
     ...params: MaybeOptionalArg<z.infer<TEndpoint["parameters"]>>
   ): Promise<z.infer<TEndpoint["response"]>> {
-    return this.fetcher("put", this.baseUrl + path, params[0]);
+    return this.fetcher("put", this.baseUrl + path, params[0]) as Promise<TEndpoint["response"]>;
   }
   // </ApiClient.put>
 
@@ -398,7 +398,7 @@ export class ApiClient {
     path: Path,
     ...params: MaybeOptionalArg<z.infer<TEndpoint["parameters"]>>
   ): Promise<z.infer<TEndpoint["response"]>> {
-    return this.fetcher("post", this.baseUrl + path, params[0]);
+    return this.fetcher("post", this.baseUrl + path, params[0]) as Promise<TEndpoint["response"]>;
   }
   // </ApiClient.post>
 
@@ -407,7 +407,7 @@ export class ApiClient {
     path: Path,
     ...params: MaybeOptionalArg<z.infer<TEndpoint["parameters"]>>
   ): Promise<z.infer<TEndpoint["response"]>> {
-    return this.fetcher("get", this.baseUrl + path, params[0]);
+    return this.fetcher("get", this.baseUrl + path, params[0]) as Promise<TEndpoint["response"]>;
   }
   // </ApiClient.get>
 
@@ -416,7 +416,7 @@ export class ApiClient {
     path: Path,
     ...params: MaybeOptionalArg<z.infer<TEndpoint["parameters"]>>
   ): Promise<z.infer<TEndpoint["response"]>> {
-    return this.fetcher("delete", this.baseUrl + path, params[0]);
+    return this.fetcher("delete", this.baseUrl + path, params[0]) as Promise<TEndpoint["response"]>;
   }
   // </ApiClient.delete>
 }


### PR DESCRIPTION
As discussed in https://github.com/astahmer/typed-openapi/issues/12#issuecomment-1866742960 this adds a typecast to the desired return type in the `ApiClient` methods when runtime is zod.