### PR TITLE
Add missing infer in zod-based ApiClient methods

### DIFF
--- a/.changeset/sharp-pillows-rule.md
+++ b/.changeset/sharp-pillows-rule.md
@@ -1,0 +1,5 @@
+---
+"typed-openapi": patch
+---
+
+Fix typecast in zod-based ApiClient methods

--- a/packages/typed-openapi/src/generator.ts
+++ b/packages/typed-openapi/src/generator.ts
@@ -294,7 +294,7 @@ export class ApiClient {
       .with("arktype", "io-ts", "typebox", "valibot", () => infer(`TEndpoint`) + `["response"]`)
       .otherwise(() => `TEndpoint["response"]`)}> {
       return this.fetcher("${method}", this.baseUrl + path, params[0])${match(ctx.runtime)
-          .with("zod", () => `as Promise<TEndpoint["response"]> `).otherwise(() => ``)};
+          .with("zod", () => `as Promise<${infer(`TEndpoint["response"]`)}>`).otherwise(() => ``)};
     }
     // </ApiClient.${method}>
     `

--- a/packages/typed-openapi/tests/snapshots/docker.openapi.zod.ts
+++ b/packages/typed-openapi/tests/snapshots/docker.openapi.zod.ts
@@ -3461,7 +3461,7 @@ export class ApiClient {
     path: Path,
     ...params: MaybeOptionalArg<z.infer<TEndpoint["parameters"]>>
   ): Promise<z.infer<TEndpoint["response"]>> {
-    return this.fetcher("get", this.baseUrl + path, params[0]) as Promise<TEndpoint["response"]>;
+    return this.fetcher("get", this.baseUrl + path, params[0]) as Promise<z.infer<TEndpoint["response"]>>;
   }
   // </ApiClient.get>
 
@@ -3470,7 +3470,7 @@ export class ApiClient {
     path: Path,
     ...params: MaybeOptionalArg<z.infer<TEndpoint["parameters"]>>
   ): Promise<z.infer<TEndpoint["response"]>> {
-    return this.fetcher("post", this.baseUrl + path, params[0]) as Promise<TEndpoint["response"]>;
+    return this.fetcher("post", this.baseUrl + path, params[0]) as Promise<z.infer<TEndpoint["response"]>>;
   }
   // </ApiClient.post>
 
@@ -3479,7 +3479,7 @@ export class ApiClient {
     path: Path,
     ...params: MaybeOptionalArg<z.infer<TEndpoint["parameters"]>>
   ): Promise<z.infer<TEndpoint["response"]>> {
-    return this.fetcher("delete", this.baseUrl + path, params[0]) as Promise<TEndpoint["response"]>;
+    return this.fetcher("delete", this.baseUrl + path, params[0]) as Promise<z.infer<TEndpoint["response"]>>;
   }
   // </ApiClient.delete>
 
@@ -3488,7 +3488,7 @@ export class ApiClient {
     path: Path,
     ...params: MaybeOptionalArg<z.infer<TEndpoint["parameters"]>>
   ): Promise<z.infer<TEndpoint["response"]>> {
-    return this.fetcher("put", this.baseUrl + path, params[0]) as Promise<TEndpoint["response"]>;
+    return this.fetcher("put", this.baseUrl + path, params[0]) as Promise<z.infer<TEndpoint["response"]>>;
   }
   // </ApiClient.put>
 
@@ -3497,7 +3497,7 @@ export class ApiClient {
     path: Path,
     ...params: MaybeOptionalArg<z.infer<TEndpoint["parameters"]>>
   ): Promise<z.infer<TEndpoint["response"]>> {
-    return this.fetcher("head", this.baseUrl + path, params[0]) as Promise<TEndpoint["response"]>;
+    return this.fetcher("head", this.baseUrl + path, params[0]) as Promise<z.infer<TEndpoint["response"]>>;
   }
   // </ApiClient.head>
 }

--- a/packages/typed-openapi/tests/snapshots/petstore.zod.ts
+++ b/packages/typed-openapi/tests/snapshots/petstore.zod.ts
@@ -389,7 +389,7 @@ export class ApiClient {
     path: Path,
     ...params: MaybeOptionalArg<z.infer<TEndpoint["parameters"]>>
   ): Promise<z.infer<TEndpoint["response"]>> {
-    return this.fetcher("put", this.baseUrl + path, params[0]) as Promise<TEndpoint["response"]>;
+    return this.fetcher("put", this.baseUrl + path, params[0]) as Promise<z.infer<TEndpoint["response"]>>;
   }
   // </ApiClient.put>
 
@@ -398,7 +398,7 @@ export class ApiClient {
     path: Path,
     ...params: MaybeOptionalArg<z.infer<TEndpoint["parameters"]>>
   ): Promise<z.infer<TEndpoint["response"]>> {
-    return this.fetcher("post", this.baseUrl + path, params[0]) as Promise<TEndpoint["response"]>;
+    return this.fetcher("post", this.baseUrl + path, params[0]) as Promise<z.infer<TEndpoint["response"]>>;
   }
   // </ApiClient.post>
 
@@ -407,7 +407,7 @@ export class ApiClient {
     path: Path,
     ...params: MaybeOptionalArg<z.infer<TEndpoint["parameters"]>>
   ): Promise<z.infer<TEndpoint["response"]>> {
-    return this.fetcher("get", this.baseUrl + path, params[0]) as Promise<TEndpoint["response"]>;
+    return this.fetcher("get", this.baseUrl + path, params[0]) as Promise<z.infer<TEndpoint["response"]>>;
   }
   // </ApiClient.get>
 
@@ -416,7 +416,7 @@ export class ApiClient {
     path: Path,
     ...params: MaybeOptionalArg<z.infer<TEndpoint["parameters"]>>
   ): Promise<z.infer<TEndpoint["response"]>> {
-    return this.fetcher("delete", this.baseUrl + path, params[0]) as Promise<TEndpoint["response"]>;
+    return this.fetcher("delete", this.baseUrl + path, params[0]) as Promise<z.infer<TEndpoint["response"]>>;
   }
   // </ApiClient.delete>
 }


### PR DESCRIPTION
In my previous commit I missed the `z.infer` in the typecast. That seems to work fine as long as per Endpoint-Type (get, ...) there are multiple endpoints. Only if you have exactly one endpoint typescript complains. 