### PR TITLE
add options to `Method` type in `generateApiClient` function

### DIFF
--- a/.changeset/tall-bees-impress.md
+++ b/.changeset/tall-bees-impress.md
@@ -1,0 +1,6 @@
+---
+"typed-openapi": minor
+---
+
+Add options to `Method` type in `generateApiClient` function as fix for
+[#55](https://github.com/astahmer/typed-openapi/issues/55)

--- a/packages/typed-openapi/src/generator.ts
+++ b/packages/typed-openapi/src/generator.ts
@@ -234,7 +234,7 @@ export type EndpointParameters = {
 };
 
 export type MutationMethod = "post" | "put" | "patch" | "delete";
-export type Method = "get" | "head" | MutationMethod;
+export type Method = "get" | "head" | "options" | MutationMethod;
 
 type RequestFormat = "json" | "form-data" | "form-url" | "binary" | "text";
 


### PR DESCRIPTION
Potential fix for #55 