### PR TITLE
deps: move @changesets/cli to devDependencies

### DIFF
--- a/packages/typed-openapi/package.json
+++ b/packages/typed-openapi/package.json
@@ -21,7 +21,6 @@
   },
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.1.0",
-    "@changesets/cli": "^2.26.2",
     "@sinclair/typebox-codegen": "^0.10.5",
     "arktype": "1.0.18-alpha",
     "cac": "^6.7.14",
@@ -32,6 +31,7 @@
     "ts-pattern": "^5.0.4"
   },
   "devDependencies": {
+    "@changesets/cli": "^2.26.2",
     "@types/node": "^20.4.5",
     "@types/prettier": "2.7.3",
     "tsup": "^7.1.0",


### PR DESCRIPTION
This will remove a lot of audit issues related to `cross-spawn`:

```
└─┬ typed-openapi@0.9.0
  └─┬ @changesets/cli@2.27.9
    └─┬ spawndamnit@2.0.0
      └── cross-spawn@5.1.0
```

See https://github.com/advisories/GHSA-3xgq-45jj-v275.