### PR TITLE
feat: add CLI option --schemas-only

### DIFF
--- a/.changeset/thick-readers-turn.md
+++ b/.changeset/thick-readers-turn.md
@@ -1,0 +1,5 @@
+---
+"typed-openapi": minor
+---
+
+Add CLI option `--schemas-only` to allow generation of only the schema without endpoints and api client

--- a/packages/typed-openapi/src/cli.ts
+++ b/packages/typed-openapi/src/cli.ts
@@ -16,6 +16,11 @@ cli
     { default: "none" },
   )
   .option("--tanstack [name]", "Generate tanstack client, defaults to false, can optionally specify a name for the generated file")
+  .option(
+    "--schemas-only",
+    "Only generate schemas, skipping client generation (defaults to false)",
+    { default : false },
+  )
   .action(async (input, _options) => {
     return generateClientFiles(input, _options);
   });

--- a/packages/typed-openapi/src/generator.ts
+++ b/packages/typed-openapi/src/generator.ts
@@ -9,6 +9,7 @@ import { wrapWithQuotesIfNeeded } from "./string-utils.ts";
 
 type GeneratorOptions = ReturnType<typeof mapOpenApiEndpoints> & {
   runtime?: "none" | keyof typeof runtimeValidationGenerator;
+  schemasOnly?: boolean;
 };
 type GeneratorContext = Required<GeneratorOptions>;
 
@@ -56,8 +57,8 @@ export const generateFile = (options: GeneratorOptions) => {
   const ctx = { ...options, runtime: options.runtime ?? "none" } as GeneratorContext;
 
   const schemaList = generateSchemaList(ctx);
-  const endpointSchemaList = generateEndpointSchemaList(ctx);
-  const apiClient = generateApiClient(ctx);
+  const endpointSchemaList = options.schemasOnly ? "" : generateEndpointSchemaList(ctx);
+  const apiClient = options.schemasOnly ? "" : generateApiClient(ctx);
 
   const transform =
     ctx.runtime === "none"

--- a/packages/typed-openapi/tests/generator.test.ts
+++ b/packages/typed-openapi/tests/generator.test.ts
@@ -414,6 +414,49 @@ describe("generator", () => {
     `);
   });
 
+  test("petstore schema only", async ({ expect }) => {
+    const openApiDoc = (await SwaggerParser.parse("./tests/samples/petstore.yaml")) as OpenAPIObject;
+    expect(await prettify(generateFile({...mapOpenApiEndpoints(openApiDoc), schemasOnly: true}))).toMatchInlineSnapshot(`
+      "export namespace Schemas {
+        // <Schemas>
+        export type Order = Partial<{
+          id: number;
+          petId: number;
+          quantity: number;
+          shipDate: string;
+          status: "placed" | "approved" | "delivered";
+          complete: boolean;
+        }>;
+        export type Address = Partial<{ street: string; city: string; state: string; zip: string }>;
+        export type Customer = Partial<{ id: number; username: string; address: Array<Address> }>;
+        export type Category = Partial<{ id: number; name: string }>;
+        export type User = Partial<{
+          id: number;
+          username: string;
+          firstName: string;
+          lastName: string;
+          email: string;
+          password: string;
+          phone: string;
+          userStatus: number;
+        }>;
+        export type Tag = Partial<{ id: number; name: string }>;
+        export type Pet = {
+          id?: number | undefined;
+          name: string;
+          category?: Category | undefined;
+          photoUrls: Array<string>;
+          tags?: Array<Tag> | undefined;
+          status?: ("available" | "pending" | "sold") | undefined;
+        };
+        export type ApiResponse = Partial<{ code: number; type: string; message: string }>;
+
+        // </Schemas>
+      }
+      "
+    `);
+  });
+
   test("nullable string", async ({ expect }) => {
     expect(await prettify(generateFile(mapOpenApiEndpoints({
       "openapi": "3.0.0",


### PR DESCRIPTION
Add CLI option `--schemas-only` to allow generation of only the schema without endpoints and api client