### PR TITLE
fix issue with singleton enum

### DIFF
--- a/.changeset/plenty-ways-drum.md
+++ b/.changeset/plenty-ways-drum.md
@@ -1,0 +1,5 @@
+---
+"typed-openapi": patch
+---
+
+closes: #79 by handling singleton enum of type number

--- a/packages/typed-openapi/src/openapi-schema-to-ts.ts
+++ b/packages/typed-openapi/src/openapi-schema-to-ts.ts
@@ -65,7 +65,17 @@ export const openApiSchemaToTs = ({ schema, meta: _inheritedMeta, ctx }: Openapi
       if (schema.enum) {
         if (schema.enum.length === 1) {
           const value = schema.enum[0];
-          return t.literal(value === null ? "null" : value === true ? "true" : value === false ? "false" : `"${value}"`);
+          if (value === null) {
+            return t.literal("null");
+          } else if (value === true) {
+            return t.literal("true");
+          } else if (value === false) {
+            return t.literal("false");
+          } else if (typeof value === "number") {
+            return t.literal(`${value}`)
+          } else {
+            return t.literal(`"${value}"`);
+          }
         }
 
         if (schemaType === "string") {

--- a/packages/typed-openapi/tests/openapi-schema-to-ts.test.ts
+++ b/packages/typed-openapi/tests/openapi-schema-to-ts.test.ts
@@ -358,6 +358,13 @@ test("getSchemaBox", () => {
     }
   `);
 
+  expect(getSchemaBox({ type: "number", enum: [1] })).toMatchInlineSnapshot(`
+    {
+      "type": "literal",
+      "value": "1",
+    }
+  `);
+
   expect(getSchemaBox({
     "type": "object",
     "properties": {


### PR DESCRIPTION
Small change to support a numeric enum with a single value. Multiple values are modeled correctly, but a single value is written as a string literal. 

closes: #79 