### PR TITLE
support enum without a type field

### DIFF
--- a/.changeset/cyan-tables-fetch.md
+++ b/.changeset/cyan-tables-fetch.md
@@ -1,0 +1,5 @@
+---
+"typed-openapi": patch
+---
+
+closes: #82 by supporting enum without type

--- a/.changeset/plenty-ways-drum.md
+++ b/.changeset/plenty-ways-drum.md
@@ -1,0 +1,5 @@
+---
+"typed-openapi": patch
+---
+
+closes: #79 by handling singleton enum of type number

--- a/.changeset/plenty-ways-drum.md
+++ b/.changeset/plenty-ways-drum.md
@@ -1,5 +1,0 @@
----
-"typed-openapi": patch
----
-
-closes: #79 by handling singleton enum of type number

--- a/packages/typed-openapi/src/openapi-schema-to-ts.ts
+++ b/packages/typed-openapi/src/openapi-schema-to-ts.ts
@@ -94,6 +94,18 @@ export const openApiSchemaToTs = ({ schema, meta: _inheritedMeta, ctx }: Openapi
       if (schemaType === "number" || schemaType === "integer") return t.number();
       if (schemaType === "null") return t.literal("null");
     }
+    if (!schemaType && schema.enum) {
+      return t.union(schema.enum.map((value) => {
+        if (typeof value === "string") {
+          return t.literal(`"${value}"`)
+        }
+        if (value === null) {
+          return t.literal("null")
+        }
+        // handle boolean and number literals
+        return t.literal(value)
+      }));
+    }
 
     if (schemaType === "array") {
       if (schema.items) {

--- a/packages/typed-openapi/src/openapi-schema-to-ts.ts
+++ b/packages/typed-openapi/src/openapi-schema-to-ts.ts
@@ -65,7 +65,17 @@ export const openApiSchemaToTs = ({ schema, meta: _inheritedMeta, ctx }: Openapi
       if (schema.enum) {
         if (schema.enum.length === 1) {
           const value = schema.enum[0];
-          return t.literal(value === null ? "null" : value === true ? "true" : value === false ? "false" : `"${value}"`);
+          if (value === null) {
+            return t.literal("null");
+          } else if (value === true) {
+            return t.literal("true");
+          } else if (value === false) {
+            return t.literal("false");
+          } else if (typeof value === "number") {
+            return t.literal(`${value}`)
+          } else {
+            return t.literal(`"${value}"`);
+          }
         }
 
         if (schemaType === "string") {

--- a/packages/typed-openapi/tests/openapi-schema-to-ts.test.ts
+++ b/packages/typed-openapi/tests/openapi-schema-to-ts.test.ts
@@ -365,6 +365,16 @@ test("getSchemaBox", () => {
     }
   `);
 
+  expect(getSchemaBox({ enum: ["red", "amber", "green", null, 42, true] })).toMatchInlineSnapshot(
+    `
+    {
+      "type": "union",
+      "value": "("red" | "amber" | "green" | null | 42 | true)",
+    }
+  `,
+  );
+
+
   expect(getSchemaBox({
     "type": "object",
     "properties": {

--- a/packages/typed-openapi/tests/openapi-schema-to-ts.test.ts
+++ b/packages/typed-openapi/tests/openapi-schema-to-ts.test.ts
@@ -358,6 +358,13 @@ test("getSchemaBox", () => {
     }
   `);
 
+  expect(getSchemaBox({ type: "number", enum: [1] })).toMatchInlineSnapshot(`
+    {
+      "type": "literal",
+      "value": "1",
+    }
+  `);
+
   expect(getSchemaBox({
     "type": "object",
     "properties": {


### PR DESCRIPTION
Small change to `openapi-schema-to-ts` to support an enum without a type field.

closes #82 