### PR TITLE
closes #85. Adds support for extended types with allOf.

### DIFF
--- a/.changeset/plain-dolls-give.md
+++ b/.changeset/plain-dolls-give.md
@@ -1,0 +1,5 @@
+---
+"typed-openapi": patch
+---
+
+closes #85. Adds support for extended types with allOf.

--- a/packages/typed-openapi/src/openapi-schema-to-ts.ts
+++ b/packages/typed-openapi/src/openapi-schema-to-ts.ts
@@ -52,11 +52,11 @@ export const openApiSchemaToTs = ({ schema, meta: _inheritedMeta, ctx }: Openapi
     }
 
     if (schema.allOf) {
-      if (schema.allOf.length === 1) {
-        return openApiSchemaToTs({ schema: schema.allOf[0]!, ctx, meta });
-      }
-
       const types = schema.allOf.map((prop) => openApiSchemaToTs({ schema: prop, ctx, meta }));
+      const {allOf, externalDocs,  example, examples, description, title,  ...rest} = schema
+      if (Object.keys(rest).length > 0) {
+        types.push(openApiSchemaToTs({schema: rest, ctx, meta}))
+      }
       return t.intersection(types);
     }
 

--- a/packages/typed-openapi/tests/openapi-schema-to-ts.test.ts
+++ b/packages/typed-openapi/tests/openapi-schema-to-ts.test.ts
@@ -1,4 +1,3 @@
-
 import type { SchemasObject } from "openapi3-ts/oas31";
 import { describe, expect, test } from "vitest";
 
@@ -445,6 +444,36 @@ describe("getSchemaBox with context", () => {
       {
         "type": "ref",
         "value": "Partial<{ str: string, nb: number, nested: Nested }>",
+      }
+    `,
+    );
+  });
+
+  test("with ref and allOf", () => {
+    const schemas = {
+      Extends: {
+        allOf: [{$ref: "#/components/schemas/Base"}],
+        type: "object",
+        properties: {
+          str: { type: "string" },
+          nb: { type: "number" },
+        },
+        required: ["str"],
+      },
+      Base: {
+        type: "object",
+        properties: {
+          baseProp: { type: "string" },
+        }
+      },
+    } satisfies SchemasObject;
+
+    const ctx = makeCtx(schemas);
+    expect(openApiSchemaToTs({ schema: schemas["Extends"]!, ctx })).toMatchInlineSnapshot(
+      `
+      {
+        "type": "intersection",
+        "value": "(Base & { str: string, nb?: number | undefined })",
       }
     `,
     );


### PR DESCRIPTION
small change to recurse if there are additional properties to process on the SchemaObject after handling the allOf.

See in the PR where I remove the `allOf` property and any other properties like `description` that don't affect the definition before seeing if I need to recurse.

My initial use case is for an object with its own `properties` and `required`. Maybe it would be better to check for the presence of a few properties instead of removing the non-behavior properties. I'm open to changing this implementation. I didn't consider the case of extension properties and only thought to remove `description` and others when an existing test failed.

Maybe a simpler approach would be to just remove the `allOf` and then recurse but don't add the result to the intersection if it's an `unknown` type.