### PR TITLE
Add response headers

### DIFF
--- a/.changeset/mean-walls-lick.md
+++ b/.changeset/mean-walls-lick.md
@@ -1,0 +1,5 @@
+---
+"typed-openapi": minor
+---
+
+Add response headers in endpoint types

--- a/packages/typed-openapi/src/generator.ts
+++ b/packages/typed-openapi/src/generator.ts
@@ -70,29 +70,29 @@ export const generateFile = (options: GeneratorOptions) => {
     ctx.runtime === "none"
       ? (file: string) => file
       : (file: string) => {
-          const model = Codegen.TypeScriptToModel.Generate(file);
-          const transformer = runtimeValidationGenerator[ctx.runtime as Exclude<typeof ctx.runtime, "none">];
-          // tmp fix for typebox, there's currently a "// todo" only with Codegen.ModelToTypeBox.Generate
-          // https://github.com/sinclairzx81/typebox-codegen/blob/44d44d55932371b69f349331b1c8a60f5d760d9e/src/model/model-to-typebox.ts#L31
-          const generated = ctx.runtime === "typebox" ? Codegen.TypeScriptToTypeBox.Generate(file) : transformer(model);
+        const model = Codegen.TypeScriptToModel.Generate(file);
+        const transformer = runtimeValidationGenerator[ctx.runtime as Exclude<typeof ctx.runtime, "none">];
+        // tmp fix for typebox, there's currently a "// todo" only with Codegen.ModelToTypeBox.Generate
+        // https://github.com/sinclairzx81/typebox-codegen/blob/44d44d55932371b69f349331b1c8a60f5d760d9e/src/model/model-to-typebox.ts#L31
+        const generated = ctx.runtime === "typebox" ? Codegen.TypeScriptToTypeBox.Generate(file) : transformer(model);
 
-          let converted = "";
-          const match = generated.match(/(const __ENDPOINTS_START__ =)([\s\S]*?)(export type __ENDPOINTS_END__)/);
-          const content = match?.[2];
+        let converted = "";
+        const match = generated.match(/(const __ENDPOINTS_START__ =)([\s\S]*?)(export type __ENDPOINTS_END__)/);
+        const content = match?.[2];
 
-          if (content && ctx.runtime in replacerByRuntime) {
-            const before = generated.slice(0, generated.indexOf("export type __ENDPOINTS_START"));
-            converted =
-              before +
-              replacerByRuntime[ctx.runtime as keyof typeof replacerByRuntime](
-                content.slice(content.indexOf("export")),
-              );
-          } else {
-            converted = generated;
-          }
+        if (content && ctx.runtime in replacerByRuntime) {
+          const before = generated.slice(0, generated.indexOf("export type __ENDPOINTS_START"));
+          converted =
+            before +
+            replacerByRuntime[ctx.runtime as keyof typeof replacerByRuntime](
+              content.slice(content.indexOf("export")),
+            );
+        } else {
+          converted = generated;
+        }
 
-          return converted;
-        };
+        return converted;
+      };
 
   const file = `
   ${transform(schemaList + endpointSchemaList)}
@@ -132,6 +132,24 @@ const parameterObjectToString = (parameters: Box<AnyBoxDef> | Record<string, Any
   }
   return str + "}";
 };
+
+const responseHeadersObjectToString = (responseHeaders: Record<string, AnyBox>, ctx: GeneratorContext) => {
+  let str = "{";
+  for (const [key, responseHeader] of Object.entries(responseHeaders)) {
+    const value = ctx.runtime === "none"
+        ? responseHeader.recompute((box) => {
+          if (Box.isReference(box) && !box.params.generics && box.value !== "null") {
+            box.value = `Schemas.${box.value}`;
+          }
+
+          return box;
+        }).value
+        : responseHeader.value
+    str += `${wrapWithQuotesIfNeeded(key.toLowerCase())}: ${value},\n`;
+  }
+  return str + "}";
+}
+
 const generateEndpointSchemaList = (ctx: GeneratorContext) => {
   let file = `
   ${ctx.runtime === "none" ? "export namespace Endpoints {" : ""}
@@ -145,39 +163,42 @@ const generateEndpointSchemaList = (ctx: GeneratorContext) => {
       path: "${endpoint.path}",
       requestFormat: "${endpoint.requestFormat}",
       ${
-        endpoint.meta.hasParameters
-          ? `parameters: {
+      endpoint.meta.hasParameters
+        ? `parameters: {
             ${parameters.query ? `query:  ${parameterObjectToString(parameters.query)},` : ""}
         ${parameters.path ? `path:  ${parameterObjectToString(parameters.path)},` : ""}
         ${parameters.header ? `header:  ${parameterObjectToString(parameters.header)},` : ""}
         ${
           parameters.body
             ? `body:  ${parameterObjectToString(
-                ctx.runtime === "none"
-                  ? parameters.body.recompute((box) => {
-                      if (Box.isReference(box) && !box.params.generics) {
-                        box.value = `Schemas.${box.value}`;
-                      }
-                      return box;
-                    })
-                  : parameters.body,
-              )},`
+              ctx.runtime === "none"
+                ? parameters.body.recompute((box) => {
+                  if (Box.isReference(box) && !box.params.generics) {
+                    box.value = `Schemas.${box.value}`;
+                  }
+                  return box;
+                })
+                : parameters.body,
+            )},`
             : ""
         }
           }`
-          : "parameters: never,"
-      }
+        : "parameters: never,"
+    }
       response: ${
-        ctx.runtime === "none"
-          ? endpoint.response.recompute((box) => {
-              if (Box.isReference(box) && !box.params.generics && box.value !== "null") {
-                box.value = `Schemas.${box.value}`;
-              }
+      ctx.runtime === "none"
+        ? endpoint.response.recompute((box) => {
+          if (Box.isReference(box) && !box.params.generics && box.value !== "null") {
+            box.value = `Schemas.${box.value}`;
+          }
 
-              return box;
-            }).value
-          : endpoint.response.value
-      },
+          return box;
+        }).value
+        : endpoint.response.value
+    },
+      ${
+      endpoint.responseHeaders ? `responseHeaders: ${responseHeadersObjectToString(endpoint.responseHeaders, ctx)},` : ""
+    }
     }\n`;
   });
 
@@ -199,14 +220,14 @@ const generateEndpointByMethod = (ctx: GeneratorContext) => {
      // <EndpointByMethod>
      export ${ctx.runtime === "none" ? "type" : "const"} EndpointByMethod = {
      ${Object.entries(byMethods)
-       .map(([method, list]) => {
-         return `${method}: {
+    .map(([method, list]) => {
+      return `${method}: {
            ${list.map(
-             (endpoint) => `"${endpoint.path}": ${ctx.runtime === "none" ? "Endpoints." : ""}${endpoint.meta.alias}`,
-           )}
+        (endpoint) => `"${endpoint.path}": ${ctx.runtime === "none" ? "Endpoints." : ""}${endpoint.meta.alias}`,
+      )}
          }`;
-       })
-       .join(",\n")}
+    })
+    .join(",\n")}
      }
      ${ctx.runtime === "none" ? "" : "export type EndpointByMethod = typeof EndpointByMethod;"}
      // </EndpointByMethod>
@@ -216,8 +237,8 @@ const generateEndpointByMethod = (ctx: GeneratorContext) => {
 
     // <EndpointByMethod.Shorthands>
     ${Object.keys(byMethods)
-      .map((method) => `export type ${capitalize(method)}Endpoints = EndpointByMethod["${method}"]`)
-      .join("\n")}
+    .map((method) => `export type ${capitalize(method)}Endpoints = EndpointByMethod["${method}"]`)
+    .join("\n")}
     // </EndpointByMethod.Shorthands>
     `;
 
@@ -246,6 +267,7 @@ type RequestFormat = "json" | "form-data" | "form-url" | "binary" | "text";
 export type DefaultEndpoint = {
   parameters?: EndpointParameters | undefined;
   response: unknown;
+  responseHeaders?: Record<string, unknown>;
 };
 
 export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -260,6 +282,7 @@ export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
     areParametersRequired: boolean;
   };
   response: TConfig["response"];
+  responseHeaders?: TConfig["responseHeaders"]
 };
 
 export type Fetcher = (method: Method, url: string, parameters?: EndpointParameters | undefined) => Promise<Response>;
@@ -303,18 +326,18 @@ export class ApiClient {
     ${method}<Path extends keyof ${capitalizedMethod}Endpoints, TEndpoint extends ${capitalizedMethod}Endpoints[Path]>(
       path: Path,
       ...params: MaybeOptionalArg<${match(ctx.runtime)
-        .with("zod", "yup", () => infer(`TEndpoint["parameters"]`))
-        .with("arktype", "io-ts", "typebox", "valibot", () => infer(`TEndpoint`) + `["parameters"]`)
-        .otherwise(() => `TEndpoint["parameters"]`)}>
+          .with("zod", "yup", () => infer(`TEndpoint["parameters"]`))
+          .with("arktype", "io-ts", "typebox", "valibot", () => infer(`TEndpoint`) + `["parameters"]`)
+          .otherwise(() => `TEndpoint["parameters"]`)}>
     ): Promise<${match(ctx.runtime)
-      .with("zod", "yup", () => infer(`TEndpoint["response"]`))
-      .with("arktype", "io-ts", "typebox", "valibot", () => infer(`TEndpoint`) + `["response"]`)
-      .otherwise(() => `TEndpoint["response"]`)}> {
+          .with("zod", "yup", () => infer(`TEndpoint["response"]`))
+          .with("arktype", "io-ts", "typebox", "valibot", () => infer(`TEndpoint`) + `["response"]`)
+          .otherwise(() => `TEndpoint["response"]`)}> {
       return this.fetcher("${method}", this.baseUrl + path, params[0])
           .then(response => this.parseResponse(response))${match(ctx.runtime)
-            .with("zod", "yup", () => `as Promise<${infer(`TEndpoint["response"]`)}>`)
-            .with("arktype", "io-ts", "typebox", "valibot", () => `as Promise<${infer(`TEndpoint`) + `["response"]`}>`)
-            .otherwise(() => `as Promise<TEndpoint["response"]>`)};
+          .with("zod", "yup", () => `as Promise<${infer(`TEndpoint["response"]`)}>`)
+          .with("arktype", "io-ts", "typebox", "valibot", () => `as Promise<${infer(`TEndpoint`) + `["response"]`}>`)
+          .otherwise(() => `as Promise<TEndpoint["response"]>`)};
     }
     // </ApiClient.${method}>
     `
@@ -334,17 +357,17 @@ export class ApiClient {
       method: TMethod,
       path: TPath,
       ...params: MaybeOptionalArg<${match(ctx.runtime)
-        .with("zod", "yup", () =>
-          inferByRuntime[ctx.runtime](`TEndpoint extends { parameters: infer Params } ? Params : never`),
-        )
-        .with(
-          "arktype",
-          "io-ts",
-          "typebox",
-          "valibot",
-          () => inferByRuntime[ctx.runtime](`TEndpoint`) + `["parameters"]`,
-        )
-        .otherwise(() => `TEndpoint extends { parameters: infer Params } ? Params : never`)}>)
+    .with("zod", "yup", () =>
+      inferByRuntime[ctx.runtime](`TEndpoint extends { parameters: infer Params } ? Params : never`),
+    )
+    .with(
+      "arktype",
+      "io-ts",
+      "typebox",
+      "valibot",
+      () => inferByRuntime[ctx.runtime](`TEndpoint`) + `["parameters"]`,
+    )
+    .otherwise(() => `TEndpoint extends { parameters: infer Params } ? Params : never`)}>)
     : Promise<Omit<Response, "json"> & {
       /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/json) */
       json: () => Promise<TEndpoint extends { response: infer Res } ? Res : never>;

--- a/packages/typed-openapi/src/map-openapi-endpoints.ts
+++ b/packages/typed-openapi/src/map-openapi-endpoints.ts
@@ -145,6 +145,16 @@ export const mapOpenApiEndpoints = (doc: OpenAPIObject) => {
         }
       }
 
+      // Map response headers
+      const headers = responseObject?.headers;
+      if (headers) {
+        endpoint.responseHeaders = Object.entries(headers).reduce((acc, [name, headerOrRef]) => {
+          const header = refs.unwrap(headerOrRef);
+          acc[name] = openApiSchemaToTs({ schema: header.schema ?? {}, ctx });
+          return acc;
+        }, {} as Record<string, Box>);
+      }
+
       endpointList.push(endpoint);
     });
   });
@@ -184,6 +194,7 @@ type RequestFormat = "json" | "form-data" | "form-url" | "binary" | "text";
 type DefaultEndpoint = {
   parameters?: EndpointParameters | undefined;
   response: AnyBox;
+  responseHeaders?: Record<string, AnyBox>
 };
 
 export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -198,4 +209,5 @@ export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
     areParametersRequired: boolean;
   };
   response: TConfig["response"];
+  responseHeaders?: TConfig["responseHeaders"];
 };

--- a/packages/typed-openapi/tests/generate-runtime.test.ts
+++ b/packages/typed-openapi/tests/generate-runtime.test.ts
@@ -10,7 +10,7 @@ const samples = ["petstore", "docker.openapi", "long-operation-id"];
 const runtimes = allowedRuntimes.toJsonSchema().enum;
 
 samples.forEach((sample) => {
-  describe(`generate-rutime-${sample}`, async () => {
+  describe(`generate-runtime-${sample}`, async () => {
     const filePath = `${__dirname}/samples/${sample}.yaml`;
     const openApiDoc = (await SwaggerParser.parse(filePath)) as OpenAPIObject;
     const ctx = mapOpenApiEndpoints(openApiDoc);

--- a/packages/typed-openapi/tests/generator.test.ts
+++ b/packages/typed-openapi/tests/generator.test.ts
@@ -186,6 +186,7 @@ describe("generator", () => {
             query: Partial<{ username: string; password: string }>;
           };
           response: string;
+          responseHeaders: { "X-Rate-Limit": number; "X-Expires-After": string };
         };
         export type get_LogoutUser = {
           method: "GET";
@@ -283,6 +284,7 @@ describe("generator", () => {
       export type DefaultEndpoint = {
         parameters?: EndpointParameters | undefined;
         response: unknown;
+        responseHeaders?: Record<string, unknown>;
       };
 
       export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -297,6 +299,7 @@ describe("generator", () => {
           areParametersRequired: boolean;
         };
         response: TConfig["response"];
+        responseHeaders?: TConfig["responseHeaders"];
       };
 
       export type Fetcher = (method: Method, url: string, parameters?: EndpointParameters | undefined) => Promise<Response>;
@@ -718,6 +721,7 @@ describe("generator", () => {
       export type DefaultEndpoint = {
         parameters?: EndpointParameters | undefined;
         response: unknown;
+        responseHeaders?: Record<string, unknown>;
       };
 
       export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -732,6 +736,7 @@ describe("generator", () => {
           areParametersRequired: boolean;
         };
         response: TConfig["response"];
+        responseHeaders?: TConfig["responseHeaders"];
       };
 
       export type Fetcher = (method: Method, url: string, parameters?: EndpointParameters | undefined) => Promise<Response>;
@@ -928,6 +933,7 @@ describe("generator", () => {
       export type DefaultEndpoint = {
         parameters?: EndpointParameters | undefined;
         response: unknown;
+        responseHeaders?: Record<string, unknown>;
       };
 
       export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -942,6 +948,7 @@ describe("generator", () => {
           areParametersRequired: boolean;
         };
         response: TConfig["response"];
+        responseHeaders?: TConfig["responseHeaders"];
       };
 
       export type Fetcher = (method: Method, url: string, parameters?: EndpointParameters | undefined) => Promise<Response>;

--- a/packages/typed-openapi/tests/map-openapi-endpoints.test.ts
+++ b/packages/typed-openapi/tests/map-openapi-endpoints.test.ts
@@ -2297,6 +2297,16 @@ describe("map-openapi-endpoints", () => {
               "type": "keyword",
               "value": "string",
             },
+            "responseHeaders": {
+              "X-Expires-After": {
+                "type": "keyword",
+                "value": "string",
+              },
+              "X-Rate-Limit": {
+                "type": "keyword",
+                "value": "number",
+              },
+            },
           },
           {
             "meta": {

--- a/packages/typed-openapi/tests/snapshots/docker.openapi.client.ts
+++ b/packages/typed-openapi/tests/snapshots/docker.openapi.client.ts
@@ -1152,6 +1152,7 @@ export namespace Endpoints {
       path: { id: string };
     };
     response: unknown;
+    responseHeaders: { "X-Docker-Container-Path-Stat": string };
   };
   export type post_ContainerPrune = {
     method: "POST";
@@ -1342,6 +1343,14 @@ export namespace Endpoints {
     requestFormat: "json";
     parameters: never;
     response: unknown;
+    responseHeaders: {
+      Swarm: "inactive" | "pending" | "error" | "locked" | "active/worker" | "active/manager";
+      "Docker-Experimental": boolean;
+      "Cache-Control": string;
+      Pragma: string;
+      "API-Version": string;
+      "Builder-Version": string;
+    };
   };
   export type head_SystemPingHead = {
     method: "HEAD";
@@ -1349,6 +1358,14 @@ export namespace Endpoints {
     requestFormat: "json";
     parameters: never;
     response: unknown;
+    responseHeaders: {
+      Swarm: "inactive" | "pending" | "error" | "locked" | "active/worker" | "active/manager";
+      "Docker-Experimental": boolean;
+      "Cache-Control": string;
+      Pragma: string;
+      "API-Version": string;
+      "Builder-Version": string;
+    };
   };
   export type post_ImageCommit = {
     method: "POST";
@@ -2224,6 +2241,7 @@ type RequestFormat = "json" | "form-data" | "form-url" | "binary" | "text";
 export type DefaultEndpoint = {
   parameters?: EndpointParameters | undefined;
   response: unknown;
+  responseHeaders?: Record<string, unknown>;
 };
 
 export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -2238,6 +2256,7 @@ export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
     areParametersRequired: boolean;
   };
   response: TConfig["response"];
+  responseHeaders?: TConfig["responseHeaders"];
 };
 
 export type Fetcher = (method: Method, url: string, parameters?: EndpointParameters | undefined) => Promise<Response>;

--- a/packages/typed-openapi/tests/snapshots/docker.openapi.io-ts.ts
+++ b/packages/typed-openapi/tests/snapshots/docker.openapi.io-ts.ts
@@ -2166,6 +2166,9 @@ export const head_ContainerArchiveInfo = t.type({
     }),
   }),
   response: t.unknown,
+  responseHeaders: t.type({
+    "X-Docker-Container-Path-Stat": t.string,
+  }),
 });
 
 export type post_ContainerPrune = t.TypeOf<typeof post_ContainerPrune>;
@@ -2445,6 +2448,21 @@ export const get_SystemPing = t.type({
   requestFormat: t.literal("json"),
   parameters: t.never,
   response: t.unknown,
+  responseHeaders: t.type({
+    Swarm: t.union([
+      t.literal("inactive"),
+      t.literal("pending"),
+      t.literal("error"),
+      t.literal("locked"),
+      t.literal("active/worker"),
+      t.literal("active/manager"),
+    ]),
+    "Docker-Experimental": t.boolean,
+    "Cache-Control": t.string,
+    Pragma: t.string,
+    "API-Version": t.string,
+    "Builder-Version": t.string,
+  }),
 });
 
 export type head_SystemPingHead = t.TypeOf<typeof head_SystemPingHead>;
@@ -2454,6 +2472,21 @@ export const head_SystemPingHead = t.type({
   requestFormat: t.literal("json"),
   parameters: t.never,
   response: t.unknown,
+  responseHeaders: t.type({
+    Swarm: t.union([
+      t.literal("inactive"),
+      t.literal("pending"),
+      t.literal("error"),
+      t.literal("locked"),
+      t.literal("active/worker"),
+      t.literal("active/manager"),
+    ]),
+    "Docker-Experimental": t.boolean,
+    "Cache-Control": t.string,
+    Pragma: t.string,
+    "API-Version": t.string,
+    "Builder-Version": t.string,
+  }),
 });
 
 export type post_ImageCommit = t.TypeOf<typeof post_ImageCommit>;
@@ -3628,6 +3661,7 @@ type RequestFormat = "json" | "form-data" | "form-url" | "binary" | "text";
 export type DefaultEndpoint = {
   parameters?: EndpointParameters | undefined;
   response: unknown;
+  responseHeaders?: Record<string, unknown>;
 };
 
 export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -3642,6 +3676,7 @@ export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
     areParametersRequired: boolean;
   };
   response: TConfig["response"];
+  responseHeaders?: TConfig["responseHeaders"];
 };
 
 export type Fetcher = (method: Method, url: string, parameters?: EndpointParameters | undefined) => Promise<Response>;

--- a/packages/typed-openapi/tests/snapshots/docker.openapi.typebox.ts
+++ b/packages/typed-openapi/tests/snapshots/docker.openapi.typebox.ts
@@ -2292,6 +2292,9 @@ export const head_ContainerArchiveInfo = Type.Object({
     }),
   }),
   response: Type.Unknown(),
+  responseHeaders: Type.Object({
+    "X-Docker-Container-Path-Stat": Type.String(),
+  }),
 });
 
 export type post_ContainerPrune = Static<typeof post_ContainerPrune>;
@@ -2601,6 +2604,21 @@ export const get_SystemPing = Type.Object({
   requestFormat: Type.Literal("json"),
   parameters: Type.Never(),
   response: Type.Unknown(),
+  responseHeaders: Type.Object({
+    Swarm: Type.Union([
+      Type.Literal("inactive"),
+      Type.Literal("pending"),
+      Type.Literal("error"),
+      Type.Literal("locked"),
+      Type.Literal("active/worker"),
+      Type.Literal("active/manager"),
+    ]),
+    "Docker-Experimental": Type.Boolean(),
+    "Cache-Control": Type.String(),
+    Pragma: Type.String(),
+    "API-Version": Type.String(),
+    "Builder-Version": Type.String(),
+  }),
 });
 
 export type head_SystemPingHead = Static<typeof head_SystemPingHead>;
@@ -2610,6 +2628,21 @@ export const head_SystemPingHead = Type.Object({
   requestFormat: Type.Literal("json"),
   parameters: Type.Never(),
   response: Type.Unknown(),
+  responseHeaders: Type.Object({
+    Swarm: Type.Union([
+      Type.Literal("inactive"),
+      Type.Literal("pending"),
+      Type.Literal("error"),
+      Type.Literal("locked"),
+      Type.Literal("active/worker"),
+      Type.Literal("active/manager"),
+    ]),
+    "Docker-Experimental": Type.Boolean(),
+    "Cache-Control": Type.String(),
+    Pragma: Type.String(),
+    "API-Version": Type.String(),
+    "Builder-Version": Type.String(),
+  }),
 });
 
 export type post_ImageCommit = Static<typeof post_ImageCommit>;
@@ -3877,6 +3910,7 @@ type RequestFormat = "json" | "form-data" | "form-url" | "binary" | "text";
 export type DefaultEndpoint = {
   parameters?: EndpointParameters | undefined;
   response: unknown;
+  responseHeaders?: Record<string, unknown>;
 };
 
 export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -3891,6 +3925,7 @@ export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
     areParametersRequired: boolean;
   };
   response: TConfig["response"];
+  responseHeaders?: TConfig["responseHeaders"];
 };
 
 export type Fetcher = (method: Method, url: string, parameters?: EndpointParameters | undefined) => Promise<Response>;

--- a/packages/typed-openapi/tests/snapshots/docker.openapi.valibot.ts
+++ b/packages/typed-openapi/tests/snapshots/docker.openapi.valibot.ts
@@ -2082,6 +2082,9 @@ export const head_ContainerArchiveInfo = v.object({
     }),
   }),
   response: v.unknown(),
+  responseHeaders: v.object({
+    "X-Docker-Container-Path-Stat": v.string(),
+  }),
 });
 
 export type post_ContainerPrune = v.InferOutput<typeof post_ContainerPrune>;
@@ -2361,6 +2364,21 @@ export const get_SystemPing = v.object({
   requestFormat: v.literal("json"),
   parameters: v.never(),
   response: v.unknown(),
+  responseHeaders: v.object({
+    Swarm: v.union([
+      v.literal("inactive"),
+      v.literal("pending"),
+      v.literal("error"),
+      v.literal("locked"),
+      v.literal("active/worker"),
+      v.literal("active/manager"),
+    ]),
+    "Docker-Experimental": v.boolean(),
+    "Cache-Control": v.string(),
+    Pragma: v.string(),
+    "API-Version": v.string(),
+    "Builder-Version": v.string(),
+  }),
 });
 
 export type head_SystemPingHead = v.InferOutput<typeof head_SystemPingHead>;
@@ -2370,6 +2388,21 @@ export const head_SystemPingHead = v.object({
   requestFormat: v.literal("json"),
   parameters: v.never(),
   response: v.unknown(),
+  responseHeaders: v.object({
+    Swarm: v.union([
+      v.literal("inactive"),
+      v.literal("pending"),
+      v.literal("error"),
+      v.literal("locked"),
+      v.literal("active/worker"),
+      v.literal("active/manager"),
+    ]),
+    "Docker-Experimental": v.boolean(),
+    "Cache-Control": v.string(),
+    Pragma: v.string(),
+    "API-Version": v.string(),
+    "Builder-Version": v.string(),
+  }),
 });
 
 export type post_ImageCommit = v.InferOutput<typeof post_ImageCommit>;
@@ -3540,6 +3573,7 @@ type RequestFormat = "json" | "form-data" | "form-url" | "binary" | "text";
 export type DefaultEndpoint = {
   parameters?: EndpointParameters | undefined;
   response: unknown;
+  responseHeaders?: Record<string, unknown>;
 };
 
 export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -3554,6 +3588,7 @@ export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
     areParametersRequired: boolean;
   };
   response: TConfig["response"];
+  responseHeaders?: TConfig["responseHeaders"];
 };
 
 export type Fetcher = (method: Method, url: string, parameters?: EndpointParameters | undefined) => Promise<Response>;

--- a/packages/typed-openapi/tests/snapshots/docker.openapi.yup.ts
+++ b/packages/typed-openapi/tests/snapshots/docker.openapi.yup.ts
@@ -2474,6 +2474,9 @@ export const head_ContainerArchiveInfo = {
     }),
   }),
   response: y.mixed((value): value is any => true).required() as y.MixedSchema<unknown>,
+  responseHeaders: y.object({
+    "X-Docker-Container-Path-Stat": y.string().required(),
+  }),
 };
 
 export type post_ContainerPrune = typeof post_ContainerPrune;
@@ -2770,6 +2773,14 @@ export const get_SystemPing = {
   requestFormat: y.mixed((value): value is "json" => value === "json").required(),
   parameters: y.mixed((value): value is never => false).required(),
   response: y.mixed((value): value is any => true).required() as y.MixedSchema<unknown>,
+  responseHeaders: y.object({
+    Swarm: y.mixed().oneOf(["inactive", "pending", "error", "locked", "active/worker", "active/manager"]).required(),
+    "Docker-Experimental": y.boolean().required(),
+    "Cache-Control": y.string().required(),
+    Pragma: y.string().required(),
+    "API-Version": y.string().required(),
+    "Builder-Version": y.string().required(),
+  }),
 };
 
 export type head_SystemPingHead = typeof head_SystemPingHead;
@@ -2779,6 +2790,14 @@ export const head_SystemPingHead = {
   requestFormat: y.mixed((value): value is "json" => value === "json").required(),
   parameters: y.mixed((value): value is never => false).required(),
   response: y.mixed((value): value is any => true).required() as y.MixedSchema<unknown>,
+  responseHeaders: y.object({
+    Swarm: y.mixed().oneOf(["inactive", "pending", "error", "locked", "active/worker", "active/manager"]).required(),
+    "Docker-Experimental": y.boolean().required(),
+    "Cache-Control": y.string().required(),
+    Pragma: y.string().required(),
+    "API-Version": y.string().required(),
+    "Builder-Version": y.string().required(),
+  }),
 };
 
 export type post_ImageCommit = typeof post_ImageCommit;
@@ -4060,6 +4079,7 @@ type RequestFormat = "json" | "form-data" | "form-url" | "binary" | "text";
 export type DefaultEndpoint = {
   parameters?: EndpointParameters | undefined;
   response: unknown;
+  responseHeaders?: Record<string, unknown>;
 };
 
 export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -4074,6 +4094,7 @@ export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
     areParametersRequired: boolean;
   };
   response: TConfig["response"];
+  responseHeaders?: TConfig["responseHeaders"];
 };
 
 export type Fetcher = (method: Method, url: string, parameters?: EndpointParameters | undefined) => Promise<Response>;

--- a/packages/typed-openapi/tests/snapshots/docker.openapi.zod.ts
+++ b/packages/typed-openapi/tests/snapshots/docker.openapi.zod.ts
@@ -2071,6 +2071,9 @@ export const head_ContainerArchiveInfo = {
     }),
   }),
   response: z.unknown(),
+  responseHeaders: z.object({
+    "X-Docker-Container-Path-Stat": z.string(),
+  }),
 };
 
 export type post_ContainerPrune = typeof post_ContainerPrune;
@@ -2350,6 +2353,21 @@ export const get_SystemPing = {
   requestFormat: z.literal("json"),
   parameters: z.never(),
   response: z.unknown(),
+  responseHeaders: z.object({
+    Swarm: z.union([
+      z.literal("inactive"),
+      z.literal("pending"),
+      z.literal("error"),
+      z.literal("locked"),
+      z.literal("active/worker"),
+      z.literal("active/manager"),
+    ]),
+    "Docker-Experimental": z.boolean(),
+    "Cache-Control": z.string(),
+    Pragma: z.string(),
+    "API-Version": z.string(),
+    "Builder-Version": z.string(),
+  }),
 };
 
 export type head_SystemPingHead = typeof head_SystemPingHead;
@@ -2359,6 +2377,21 @@ export const head_SystemPingHead = {
   requestFormat: z.literal("json"),
   parameters: z.never(),
   response: z.unknown(),
+  responseHeaders: z.object({
+    Swarm: z.union([
+      z.literal("inactive"),
+      z.literal("pending"),
+      z.literal("error"),
+      z.literal("locked"),
+      z.literal("active/worker"),
+      z.literal("active/manager"),
+    ]),
+    "Docker-Experimental": z.boolean(),
+    "Cache-Control": z.string(),
+    Pragma: z.string(),
+    "API-Version": z.string(),
+    "Builder-Version": z.string(),
+  }),
 };
 
 export type post_ImageCommit = typeof post_ImageCommit;
@@ -3526,6 +3559,7 @@ type RequestFormat = "json" | "form-data" | "form-url" | "binary" | "text";
 export type DefaultEndpoint = {
   parameters?: EndpointParameters | undefined;
   response: unknown;
+  responseHeaders?: Record<string, unknown>;
 };
 
 export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -3540,6 +3574,7 @@ export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
     areParametersRequired: boolean;
   };
   response: TConfig["response"];
+  responseHeaders?: TConfig["responseHeaders"];
 };
 
 export type Fetcher = (method: Method, url: string, parameters?: EndpointParameters | undefined) => Promise<Response>;

--- a/packages/typed-openapi/tests/snapshots/long-operation-id.arktype.ts
+++ b/packages/typed-openapi/tests/snapshots/long-operation-id.arktype.ts
@@ -67,6 +67,7 @@ type RequestFormat = "json" | "form-data" | "form-url" | "binary" | "text";
 export type DefaultEndpoint = {
   parameters?: EndpointParameters | undefined;
   response: unknown;
+  responseHeaders?: Record<string, unknown>;
 };
 
 export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -81,6 +82,7 @@ export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
     areParametersRequired: boolean;
   };
   response: TConfig["response"];
+  responseHeaders?: TConfig["responseHeaders"];
 };
 
 export type Fetcher = (method: Method, url: string, parameters?: EndpointParameters | undefined) => Promise<Response>;

--- a/packages/typed-openapi/tests/snapshots/long-operation-id.client.ts
+++ b/packages/typed-openapi/tests/snapshots/long-operation-id.client.ts
@@ -59,6 +59,7 @@ type RequestFormat = "json" | "form-data" | "form-url" | "binary" | "text";
 export type DefaultEndpoint = {
   parameters?: EndpointParameters | undefined;
   response: unknown;
+  responseHeaders?: Record<string, unknown>;
 };
 
 export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -73,6 +74,7 @@ export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
     areParametersRequired: boolean;
   };
   response: TConfig["response"];
+  responseHeaders?: TConfig["responseHeaders"];
 };
 
 export type Fetcher = (method: Method, url: string, parameters?: EndpointParameters | undefined) => Promise<Response>;

--- a/packages/typed-openapi/tests/snapshots/long-operation-id.io-ts.ts
+++ b/packages/typed-openapi/tests/snapshots/long-operation-id.io-ts.ts
@@ -63,6 +63,7 @@ type RequestFormat = "json" | "form-data" | "form-url" | "binary" | "text";
 export type DefaultEndpoint = {
   parameters?: EndpointParameters | undefined;
   response: unknown;
+  responseHeaders?: Record<string, unknown>;
 };
 
 export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -77,6 +78,7 @@ export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
     areParametersRequired: boolean;
   };
   response: TConfig["response"];
+  responseHeaders?: TConfig["responseHeaders"];
 };
 
 export type Fetcher = (method: Method, url: string, parameters?: EndpointParameters | undefined) => Promise<Response>;

--- a/packages/typed-openapi/tests/snapshots/long-operation-id.typebox.ts
+++ b/packages/typed-openapi/tests/snapshots/long-operation-id.typebox.ts
@@ -65,6 +65,7 @@ type RequestFormat = "json" | "form-data" | "form-url" | "binary" | "text";
 export type DefaultEndpoint = {
   parameters?: EndpointParameters | undefined;
   response: unknown;
+  responseHeaders?: Record<string, unknown>;
 };
 
 export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -79,6 +80,7 @@ export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
     areParametersRequired: boolean;
   };
   response: TConfig["response"];
+  responseHeaders?: TConfig["responseHeaders"];
 };
 
 export type Fetcher = (method: Method, url: string, parameters?: EndpointParameters | undefined) => Promise<Response>;

--- a/packages/typed-openapi/tests/snapshots/long-operation-id.valibot.ts
+++ b/packages/typed-openapi/tests/snapshots/long-operation-id.valibot.ts
@@ -63,6 +63,7 @@ type RequestFormat = "json" | "form-data" | "form-url" | "binary" | "text";
 export type DefaultEndpoint = {
   parameters?: EndpointParameters | undefined;
   response: unknown;
+  responseHeaders?: Record<string, unknown>;
 };
 
 export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -77,6 +78,7 @@ export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
     areParametersRequired: boolean;
   };
   response: TConfig["response"];
+  responseHeaders?: TConfig["responseHeaders"];
 };
 
 export type Fetcher = (method: Method, url: string, parameters?: EndpointParameters | undefined) => Promise<Response>;

--- a/packages/typed-openapi/tests/snapshots/long-operation-id.yup.ts
+++ b/packages/typed-openapi/tests/snapshots/long-operation-id.yup.ts
@@ -56,6 +56,7 @@ type RequestFormat = "json" | "form-data" | "form-url" | "binary" | "text";
 export type DefaultEndpoint = {
   parameters?: EndpointParameters | undefined;
   response: unknown;
+  responseHeaders?: Record<string, unknown>;
 };
 
 export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -70,6 +71,7 @@ export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
     areParametersRequired: boolean;
   };
   response: TConfig["response"];
+  responseHeaders?: TConfig["responseHeaders"];
 };
 
 export type Fetcher = (method: Method, url: string, parameters?: EndpointParameters | undefined) => Promise<Response>;

--- a/packages/typed-openapi/tests/snapshots/long-operation-id.zod.ts
+++ b/packages/typed-openapi/tests/snapshots/long-operation-id.zod.ts
@@ -56,6 +56,7 @@ type RequestFormat = "json" | "form-data" | "form-url" | "binary" | "text";
 export type DefaultEndpoint = {
   parameters?: EndpointParameters | undefined;
   response: unknown;
+  responseHeaders?: Record<string, unknown>;
 };
 
 export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -70,6 +71,7 @@ export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
     areParametersRequired: boolean;
   };
   response: TConfig["response"];
+  responseHeaders?: TConfig["responseHeaders"];
 };
 
 export type Fetcher = (method: Method, url: string, parameters?: EndpointParameters | undefined) => Promise<Response>;

--- a/packages/typed-openapi/tests/snapshots/petstore.arktype.ts
+++ b/packages/typed-openapi/tests/snapshots/petstore.arktype.ts
@@ -214,6 +214,10 @@ export const types = scope({
       }),
     }),
     response: "string",
+    responseHeaders: type({
+      "X-Rate-Limit": "number",
+      "X-Expires-After": "string",
+    }),
   }),
   get_LogoutUser: type({
     method: '"GET"',
@@ -374,6 +378,7 @@ type RequestFormat = "json" | "form-data" | "form-url" | "binary" | "text";
 export type DefaultEndpoint = {
   parameters?: EndpointParameters | undefined;
   response: unknown;
+  responseHeaders?: Record<string, unknown>;
 };
 
 export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -388,6 +393,7 @@ export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
     areParametersRequired: boolean;
   };
   response: TConfig["response"];
+  responseHeaders?: TConfig["responseHeaders"];
 };
 
 export type Fetcher = (method: Method, url: string, parameters?: EndpointParameters | undefined) => Promise<Response>;

--- a/packages/typed-openapi/tests/snapshots/petstore.client.ts
+++ b/packages/typed-openapi/tests/snapshots/petstore.client.ts
@@ -175,6 +175,7 @@ export namespace Endpoints {
       query: Partial<{ username: string; password: string }>;
     };
     response: string;
+    responseHeaders: { "X-Rate-Limit": number; "X-Expires-After": string };
   };
   export type get_LogoutUser = {
     method: "GET";
@@ -272,6 +273,7 @@ type RequestFormat = "json" | "form-data" | "form-url" | "binary" | "text";
 export type DefaultEndpoint = {
   parameters?: EndpointParameters | undefined;
   response: unknown;
+  responseHeaders?: Record<string, unknown>;
 };
 
 export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -286,6 +288,7 @@ export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
     areParametersRequired: boolean;
   };
   response: TConfig["response"];
+  responseHeaders?: TConfig["responseHeaders"];
 };
 
 export type Fetcher = (method: Method, url: string, parameters?: EndpointParameters | undefined) => Promise<Response>;

--- a/packages/typed-openapi/tests/snapshots/petstore.io-ts.ts
+++ b/packages/typed-openapi/tests/snapshots/petstore.io-ts.ts
@@ -263,6 +263,10 @@ export const get_LoginUser = t.type({
     }),
   }),
   response: t.string,
+  responseHeaders: t.type({
+    "X-Rate-Limit": t.number,
+    "X-Expires-After": t.string,
+  }),
 });
 
 export type get_LogoutUser = t.TypeOf<typeof get_LogoutUser>;
@@ -373,6 +377,7 @@ type RequestFormat = "json" | "form-data" | "form-url" | "binary" | "text";
 export type DefaultEndpoint = {
   parameters?: EndpointParameters | undefined;
   response: unknown;
+  responseHeaders?: Record<string, unknown>;
 };
 
 export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -387,6 +392,7 @@ export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
     areParametersRequired: boolean;
   };
   response: TConfig["response"];
+  responseHeaders?: TConfig["responseHeaders"];
 };
 
 export type Fetcher = (method: Method, url: string, parameters?: EndpointParameters | undefined) => Promise<Response>;

--- a/packages/typed-openapi/tests/snapshots/petstore.typebox.ts
+++ b/packages/typed-openapi/tests/snapshots/petstore.typebox.ts
@@ -291,6 +291,10 @@ export const get_LoginUser = Type.Object({
     ),
   }),
   response: Type.String(),
+  responseHeaders: Type.Object({
+    "X-Rate-Limit": Type.Number(),
+    "X-Expires-After": Type.String(),
+  }),
 });
 
 export type get_LogoutUser = Static<typeof get_LogoutUser>;
@@ -401,6 +405,7 @@ type RequestFormat = "json" | "form-data" | "form-url" | "binary" | "text";
 export type DefaultEndpoint = {
   parameters?: EndpointParameters | undefined;
   response: unknown;
+  responseHeaders?: Record<string, unknown>;
 };
 
 export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -415,6 +420,7 @@ export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
     areParametersRequired: boolean;
   };
   response: TConfig["response"];
+  responseHeaders?: TConfig["responseHeaders"];
 };
 
 export type Fetcher = (method: Method, url: string, parameters?: EndpointParameters | undefined) => Promise<Response>;

--- a/packages/typed-openapi/tests/snapshots/petstore.valibot.ts
+++ b/packages/typed-openapi/tests/snapshots/petstore.valibot.ts
@@ -262,6 +262,10 @@ export const get_LoginUser = v.object({
     }),
   }),
   response: v.string(),
+  responseHeaders: v.object({
+    "X-Rate-Limit": v.number(),
+    "X-Expires-After": v.string(),
+  }),
 });
 
 export type get_LogoutUser = v.InferOutput<typeof get_LogoutUser>;
@@ -372,6 +376,7 @@ type RequestFormat = "json" | "form-data" | "form-url" | "binary" | "text";
 export type DefaultEndpoint = {
   parameters?: EndpointParameters | undefined;
   response: unknown;
+  responseHeaders?: Record<string, unknown>;
 };
 
 export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -386,6 +391,7 @@ export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
     areParametersRequired: boolean;
   };
   response: TConfig["response"];
+  responseHeaders?: TConfig["responseHeaders"];
 };
 
 export type Fetcher = (method: Method, url: string, parameters?: EndpointParameters | undefined) => Promise<Response>;

--- a/packages/typed-openapi/tests/snapshots/petstore.yup.ts
+++ b/packages/typed-openapi/tests/snapshots/petstore.yup.ts
@@ -276,6 +276,10 @@ export const get_LoginUser = {
     }),
   }),
   response: y.string().required(),
+  responseHeaders: y.object({
+    "X-Rate-Limit": y.number().required(),
+    "X-Expires-After": y.string().required(),
+  }),
 };
 
 export type get_LogoutUser = typeof get_LogoutUser;
@@ -383,6 +387,7 @@ type RequestFormat = "json" | "form-data" | "form-url" | "binary" | "text";
 export type DefaultEndpoint = {
   parameters?: EndpointParameters | undefined;
   response: unknown;
+  responseHeaders?: Record<string, unknown>;
 };
 
 export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -397,6 +402,7 @@ export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
     areParametersRequired: boolean;
   };
   response: TConfig["response"];
+  responseHeaders?: TConfig["responseHeaders"];
 };
 
 export type Fetcher = (method: Method, url: string, parameters?: EndpointParameters | undefined) => Promise<Response>;

--- a/packages/typed-openapi/tests/snapshots/petstore.zod.ts
+++ b/packages/typed-openapi/tests/snapshots/petstore.zod.ts
@@ -259,6 +259,10 @@ export const get_LoginUser = {
     }),
   }),
   response: z.string(),
+  responseHeaders: z.object({
+    "X-Rate-Limit": z.number(),
+    "X-Expires-After": z.string(),
+  }),
 };
 
 export type get_LogoutUser = typeof get_LogoutUser;
@@ -366,6 +370,7 @@ type RequestFormat = "json" | "form-data" | "form-url" | "binary" | "text";
 export type DefaultEndpoint = {
   parameters?: EndpointParameters | undefined;
   response: unknown;
+  responseHeaders?: Record<string, unknown>;
 };
 
 export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
@@ -380,6 +385,7 @@ export type Endpoint<TConfig extends DefaultEndpoint = DefaultEndpoint> = {
     areParametersRequired: boolean;
   };
   response: TConfig["response"];
+  responseHeaders?: TConfig["responseHeaders"];
 };
 
 export type Fetcher = (method: Method, url: string, parameters?: EndpointParameters | undefined) => Promise<Response>;


### PR DESCRIPTION
Add response headers to endpoint types, for e.g. pagination, rate limit info, etc.