### PR TITLE
feat: CLI --default-fetcher

### DIFF
--- a/.changeset/shaggy-regions-build.md
+++ b/.changeset/shaggy-regions-build.md
@@ -1,0 +1,8 @@
+---
+"typed-openapi": patch
+---
+
+- New CLI option allow generating a fetcher and a standalone API client file (matching the example in `api-client.example.ts`).
+- Output paths for both the TanStack Query client and default fetcher can now be absolute or relative.
+- The standalone API client filename is configurable (defaults to `api.client.ts`).
+-> This makes it easier to start using the generated API clients

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See [the online playground](https://typed-openapi-astahmer.vercel.app/)
 
 ## Features
 
-- Headless API client, [bring your own fetcher](packages/typed-openapi/API_CLIENT_EXAMPLES.md#basic-api-client-api-client-examplets) (fetch, axios, ky, etc...) !
+- Headless API client, [bring your own fetcher](packages/typed-openapi/API_CLIENT_EXAMPLES.md#basic-api-client-api-client-examplets) (fetch, axios, ky, etc...) ! (You can generate that file with `--default-fetcher`)
 - Generates a fully typesafe API client with just types by default (instant suggestions)
 - **Type-safe error handling**: with discriminated unions and configurable success/error status codes
 - **withResponse & throwOnStatusError**: Get a union-style response object or throw on configured error status codes, with full type inference
@@ -42,7 +42,7 @@ npx typed-openapi -h
 ```
 
 ```sh
-typed-openapi/1.5.0
+typed-openapi/2.0.0
 
 Usage:
   $ typed-openapi <input>
@@ -58,10 +58,13 @@ Options:
   -r, --runtime <n>               Runtime to use for validation; defaults to `none`; available: Type<"arktype" | "io-ts" | "none" | "typebox" | "valibot" | "yup" | "zod"> (default: none)
   --schemas-only                  Only generate schemas, skipping client generation (defaults to false) (default: false)
   --include-client                Include API client types and implementation (defaults to true) (default: true)
-  --success-status-codes <codes>  Comma-separated list of success status codes for type-safe error handling (defaults to 2xx and 3xx ranges)
-  --tanstack [name]               Generate tanstack client with withResponse support for error handling, defaults to false, can optionally specify a name for the generated file
+  --success-status-codes <codes>  Comma-separated list of success status codes (defaults to 2xx and 3xx ranges)
+  --error-status-codes <codes>    Comma-separated list of error status codes (defaults to 4xx and 5xx ranges)
+  --tanstack [name]               Generate tanstack client, defaults to false, can optionally specify a name (will be generated next to the main file) or absolute path for the generated file
+  --default-fetcher [name]        Generate default fetcher, defaults to false, can optionally specify a name (will be generated next to the main file) or absolute path for the generated file
   -h, --help                      Display this message
   -v, --version                   Display version number
+
 ```
 
 ## Non-goals

--- a/packages/typed-openapi/package.json
+++ b/packages/typed-openapi/package.json
@@ -22,9 +22,9 @@
     "dev": "tsup --watch",
     "build": "tsup",
     "test": "vitest",
-    "generate:runtime": "node bin.js ./tests/samples/petstore.yaml --output ./tmp/generated-client.ts --tanstack generated-tanstack.ts",
+    "gen:runtime": "node bin.js ./tests/samples/petstore.yaml --output ./tmp/generated-client.ts --tanstack generated-tanstack.ts --default-fetcher",
     "test:runtime:run": "vitest run tests/integration-runtime-msw.test.ts",
-    "test:runtime": "pnpm run generate:runtime && pnpm run test:runtime:run",
+    "test:runtime": "pnpm run gen:runtime && pnpm run test:runtime:run",
     "fmt": "prettier --write src",
     "typecheck": "tsc -b ./tsconfig.build.json"
   },

--- a/packages/typed-openapi/src/cli.ts
+++ b/packages/typed-openapi/src/cli.ts
@@ -23,7 +23,11 @@ cli
   .option("--error-status-codes <codes>", "Comma-separated list of error status codes (defaults to 4xx and 5xx ranges)")
   .option(
     "--tanstack [name]",
-    "Generate tanstack client, defaults to false, can optionally specify a name for the generated file",
+    "Generate tanstack client, defaults to false, can optionally specify a name (will be generated next to the main file) or absolute path for the generated file",
+  )
+  .option(
+    "--default-fetcher [name]",
+    "Generate default fetcher, defaults to false, can optionally specify a name (will be generated next to the main file) or absolute path for the generated file",
   )
   .action(async (input: string, _options: any) => {
     return generateClientFiles(input, _options);

--- a/packages/typed-openapi/src/default-fetcher.generator.ts
+++ b/packages/typed-openapi/src/default-fetcher.generator.ts
@@ -1,0 +1,101 @@
+// The contents of api-client.example.ts (kept in sync with the file)
+export const generateDefaultFetcher = (options: {
+  envApiBaseUrl?: string | undefined;
+  clientPath?: string | undefined;
+  fetcherName?: string | undefined;
+  apiName?: string | undefined;
+}) => {
+  const {
+    envApiBaseUrl = "API_BASE_URL",
+    clientPath = "./openapi.client.ts",
+    fetcherName = "defaultFetcher",
+    apiName = "api",
+  } = options;
+  return `/**
+ * Generic API Client for typed-openapi generated code
+ *
+ * This is a simple, production-ready wrapper that you can copy and customize.
+ * It handles:
+ * - Path parameter replacement
+ * - Query parameter serialization
+ * - JSON request/response handling
+ * - Basic error handling
+ *
+ * Usage:
+ * 1. Replace './generated/api' with your actual generated file path
+ * 2. Set your ${envApiBaseUrl}
+ * 3. Customize error handling and headers as needed
+ */
+
+// @ts-ignore
+import { type Fetcher, createApiClient } from "./${clientPath}";
+
+// Basic configuration
+const ${envApiBaseUrl} = process.env["${envApiBaseUrl}"] || "https://api.example.com";
+
+/**
+ * Simple fetcher implementation without external dependencies
+ */
+export const ${fetcherName}: Fetcher = async (method, apiUrl, params) => {
+  const headers = new Headers();
+
+  // Replace path parameters (supports both {param} and :param formats)
+  const actualUrl = replacePathParams(apiUrl, (params?.path ?? {}) as Record<string, string>);
+  const url = new URL(actualUrl);
+
+  // Handle query parameters
+  if (params?.query) {
+    const searchParams = new URLSearchParams();
+    Object.entries(params.query).forEach(([key, value]) => {
+      if (value != null) {
+        // Skip null/undefined values
+        if (Array.isArray(value)) {
+          value.forEach((val) => val != null && searchParams.append(key, String(val)));
+        } else {
+          searchParams.append(key, String(value));
+        }
+      }
+    });
+    url.search = searchParams.toString();
+  }
+
+  // Handle request body for mutation methods
+  const body = ["post", "put", "patch", "delete"].includes(method.toLowerCase())
+    ? JSON.stringify(params?.body)
+    : undefined;
+
+  if (body) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  // Add custom headers
+  if (params?.header) {
+    Object.entries(params.header).forEach(([key, value]) => {
+      if (value != null) {
+        headers.set(key, String(value));
+      }
+    });
+  }
+
+  const response = await fetch(url, {
+    method: method.toUpperCase(),
+    ...(body && { body }),
+    headers,
+  });
+
+  return response;
+};
+
+/**
+ * Replace path parameters in URL
+ * Supports both OpenAPI format {param} and Express format :param
+ */
+export function replacePathParams(url: string, params: Record<string, string>): string {
+  return url
+    .replace(/\{(\\w+)\}/g, function(_, key) { return params[key] || '{' + key + '}'; })
+    .replace(/:([a-zA-Z0-9_]+)/g, function(_, key) { return params[key] || ':' + key; });
+}
+
+export const ${apiName} = createApiClient(${fetcherName}, API_BASE_URL);
+`;
+};

--- a/packages/typed-openapi/src/generator.ts
+++ b/packages/typed-openapi/src/generator.ts
@@ -487,15 +487,9 @@ export class ApiClient {
         });
 
         return promise ${match(ctx.runtime)
-            .with("zod", "yup", () => `as Promise<${infer(`TEndpoint["response"]`)}>`)
-            .with(
-              "arktype",
-              "io-ts",
-              "typebox",
-              "valibot",
-              () => `as Promise<${infer(`TEndpoint`) + `["response"]`}>`,
-            )
-            .otherwise(() => `as Promise<TEndpoint["response"]>`)}
+          .with("zod", "yup", () => `as Promise<${infer(`TEndpoint["response"]`)}>`)
+          .with("arktype", "io-ts", "typebox", "valibot", () => `as Promise<${infer(`TEndpoint`) + `["response"]`}>`)
+          .otherwise(() => `as Promise<TEndpoint["response"]>`)}
     }
     // </ApiClient.${method}>
     `


### PR DESCRIPTION
- New CLI option allow generating a fetcher and a standalone API client file (matching the example in `api-client.example.ts`).
- Output paths for both the TanStack Query client and default fetcher can now be absolute or relative.
- The standalone API client filename is configurable (defaults to `api.client.ts`).
-> This makes it easier to start using the generated API clients