### PR TITLE
chore: run type tests in CI

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -32,5 +32,8 @@ jobs:
       - name: Test
         run: pnpm test
 
+      - name: Test types
+        run: pnpm --filter typed-openapi test:types
+
       - name: Release package
         run: pnpm dlx pkg-pr-new publish './packages/typed-openapi'

--- a/packages/typed-openapi/tests/integration.types.tstyche.ts
+++ b/packages/typed-openapi/tests/integration.types.tstyche.ts
@@ -164,7 +164,7 @@ describe("Example API Client", () => {
 
   it("header specific typings are merged with overrides/HeadersInit", async () => {
     // @ts-expect-error Property 'header' is missing in type
-    const result = await api.delete("/pet/{petId}", {
+    await api.delete("/pet/{petId}", {
       path: { petId: 42 },
     });
 

--- a/packages/typed-openapi/tstyche.config.json
+++ b/packages/typed-openapi/tstyche.config.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://tstyche.org/schemas/config.json",
   "checkSuppressedErrors": true,
-  "checkSourceFiles": true,
-  "tsconfig": "./tsconfig.ci.json",
+  "checkSourceFiles": false,
   "testFileMatch": [
     "tests/*.tstyche.ts"
   ]


### PR DESCRIPTION
This adds type tests to CI runs. Seems like they are not included currently. Was this simply overlooked in #108, or I misunderstood something?

---

Glad to see you found TSTyche useful. Please, always ping me if you have any questions.