### PR TITLE
fix: parameter $ref schema inlined instead of referencing named schema

### DIFF
--- a/packages/typed-openapi/src/map-openapi-endpoints.ts
+++ b/packages/typed-openapi/src/map-openapi-endpoints.ts
@@ -52,7 +52,7 @@ export const mapOpenApiEndpoints = (doc: OpenAPIObject, options?: { nameTransfor
       const paramObjects = [...(pathItemObj.parameters ?? []), ...(operation.parameters ?? [])].reduce(
         (acc, paramOrRef) => {
           const param = refs.unwrap(paramOrRef);
-          const schema = openApiSchemaToTs({ schema: refs.unwrap(param.schema ?? {}), ctx });
+          const schema = openApiSchemaToTs({ schema: param.schema ?? {}, ctx });
 
           if (param.required) endpoint.meta.areParametersRequired = true;
           endpoint.meta.hasParameters = true;

--- a/packages/typed-openapi/tests/issue-parameter-direct-ref.test.ts
+++ b/packages/typed-openapi/tests/issue-parameter-direct-ref.test.ts
@@ -1,0 +1,49 @@
+import { describe, test } from "vitest";
+import { mapOpenApiEndpoints } from "../src/map-openapi-endpoints.ts";
+import { generateFile } from "../src/generator.ts";
+import { prettify } from "../src/format.ts";
+
+import type { OpenAPIObject, ParameterObject } from "openapi3-ts/oas31";
+
+const spec: OpenAPIObject = {
+  openapi: "3.0.3",
+  info: { title: "Test", version: "1.0.0" },
+  components: {
+    schemas: {
+      Status: {
+        type: "string",
+        enum: ["active", "inactive"],
+      },
+    },
+  },
+  paths: {
+    "/items": {
+      get: {
+        operationId: "getItems",
+        parameters: [
+          {
+            in: "query",
+            name: "status",
+            required: false,
+            schema: { $ref: "#/components/schemas/Status" },
+          } as ParameterObject,
+        ],
+        responses: {
+          "200": {
+            description: "",
+            content: { "application/json": { schema: {} } },
+          },
+        },
+      },
+    },
+  },
+};
+
+describe("parameter direct $ref should reference named schema, not inline it", () => {
+  test("query parameter with $ref schema uses Schemas namespace", async ({ expect }) => {
+    const file = generateFile(mapOpenApiEndpoints(spec));
+    const output = await prettify(file);
+    expect(output).toContain("query: Partial<{ status: Schemas.Status }>;");
+    expect(output).not.toContain('z.literal("active")');
+  });
+});


### PR DESCRIPTION
## Problem

When a parameter's `schema` is a direct `$ref`, the generated output inlines the full type instead of referencing the named schema:

```diff
- query: Partial<{ status: "active" | "inactive" }>;  // inlined ❌
+ query: Partial<{ status: Schemas.Status }>;          // named ref ✅
```

## Root cause & fix

In `map-openapi-endpoints.ts`, `param.schema` was passed through `refs.unwrap()` before being handed to `openApiSchemaToTs`:

```patch
- const schema = openApiSchemaToTs({ schema: refs.unwrap(param.schema ?? {}), ctx });
+ const schema = openApiSchemaToTs({ schema: param.schema ?? {}, ctx });
```

Note: I'm not sure whether the second `refs.unwrap` was ever intentional, or just added by analogy with the first one. All existing tests still pass after removing it, so if there was a reason for it, it isn't covered.

## Added test

`tests/issue-parameter-direct-ref.test.ts` — covers a query parameter whose schema is a direct `$ref` to a named component schema.