### PR TITLE
fix: honor operation parameter overrides

### DIFF
--- a/packages/typed-openapi/src/map-openapi-endpoints.ts
+++ b/packages/typed-openapi/src/map-openapi-endpoints.ts
@@ -72,9 +72,14 @@ export const mapOpenApiEndpoints = (doc: OpenAPIObject, options?: { nameTransfor
         header: [] as ParameterObject[],
         cookie: [] as ParameterObject[],
       };
-      const paramNodes = [...(pathItemObj.parameters ?? []), ...(operation.parameters ?? [])].reduce(
-        (acc, paramOrRef) => {
-          const param = refs.unwrap(paramOrRef);
+      const parametersByLocationAndName = new Map<string, ParameterObject>();
+      for (const paramOrRef of [...(pathItemObj.parameters ?? []), ...(operation.parameters ?? [])]) {
+        const param = refs.unwrap(paramOrRef);
+        parametersByLocationAndName.set(`${param.in}:${param.name}`, param);
+      }
+
+      const paramNodes = [...parametersByLocationAndName.values()].reduce(
+        (acc, param) => {
           const node = openApiToIr(schemaFromParameter(param), irCtx);
 
           if (param.required) endpoint.meta.areParametersRequired = true;

--- a/packages/typed-openapi/tests/map-openapi-endpoints.parameters.test.ts
+++ b/packages/typed-openapi/tests/map-openapi-endpoints.parameters.test.ts
@@ -1,0 +1,69 @@
+import SwaggerParser from "@apidevtools/swagger-parser";
+import type { OpenAPIObject } from "openapi3-ts/oas31";
+import { describe, test } from "vitest";
+import { mapOpenApiEndpoints } from "../src/map-openapi-endpoints.ts";
+
+describe("map-openapi-endpoints parameters", () => {
+  test("maps the Xquik search endpoint", async ({ expect }) => {
+    const openApiDoc = (await SwaggerParser.parse("./tests/samples/xquik-search.openapi.yaml")) as OpenAPIObject;
+
+    const endpoint = mapOpenApiEndpoints(openApiDoc).endpointList[0];
+
+    expect(endpoint).toMatchObject({
+      method: "get",
+      path: "/x/tweets/search",
+      requestFormat: "json",
+      responseFormat: "json",
+      meta: {
+        alias: "get_SearchTweets",
+        hasParameters: true,
+        areParametersRequired: true,
+      },
+      operation: {
+        operationId: "searchTweets",
+        security: [{ apiKey: [] }, { oauthBearer: [] }, {}],
+      },
+    });
+    expect(endpoint?.parameters?.query).toMatchObject({
+      kind: "object",
+      partial: false,
+      required: ["q"],
+      properties: {
+        q: { kind: "string" },
+        queryType: { kind: "enum" },
+        cursor: { kind: "string" },
+        limit: { kind: "number", integer: true },
+      },
+    });
+    expect(endpoint?.responses?.["200"]).toBeDefined();
+  });
+
+  test("operation parameters override matching path parameters", ({ expect }) => {
+    const openApiDoc = {
+      openapi: "3.1.0",
+      info: { title: "Parameter overrides", version: "1.0.0" },
+      paths: {
+        "/search": {
+          parameters: [{ name: "limit", in: "query", required: true, schema: { type: "string" } }],
+          get: {
+            operationId: "search",
+            parameters: [{ name: "limit", in: "query", required: false, schema: { type: "integer" } }],
+            responses: { "200": { description: "Search results" } },
+          },
+        },
+      },
+    } satisfies OpenAPIObject;
+
+    const endpoint = mapOpenApiEndpoints(openApiDoc).endpointList[0];
+
+    expect(endpoint?.meta).toMatchObject({ hasParameters: true, areParametersRequired: false });
+    expect(endpoint?.parameters?.query).toMatchObject({
+      kind: "object",
+      partial: true,
+      required: [],
+      properties: {
+        limit: { kind: "number", integer: true },
+      },
+    });
+  });
+});

--- a/packages/typed-openapi/tests/samples/xquik-search.openapi.yaml
+++ b/packages/typed-openapi/tests/samples/xquik-search.openapi.yaml
@@ -1,0 +1,75 @@
+openapi: 3.1.0
+info:
+  title: Xquik API
+  version: "1.0"
+  description: >-
+    Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
+servers:
+  - url: https://xquik.com/api/v1
+paths:
+  /x/tweets/search:
+    get:
+      operationId: searchTweets
+      summary: Search tweets
+      security:
+        - apiKey: []
+        - oauthBearer: []
+        - {}
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: queryType
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [Latest, Top]
+            default: Latest
+        - name: cursor
+          in: query
+          schema:
+            type: string
+        - name: sinceTime
+          in: query
+          schema:
+            type: string
+        - name: untilTime
+          in: query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 20
+            maximum: 200
+      responses:
+        "200":
+          description: Search results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tweets:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties: true
+                  has_next_page:
+                    type: boolean
+                  next_cursor:
+                    type: string
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: x-api-key
+    oauthBearer:
+      type: http
+      scheme: bearer


### PR DESCRIPTION
## Summary

- Fix OpenAPI parameter overrides before Schema IR conversion.
- Match parameters by `in` and `name`, as OpenAPI requires.
- Cover required path parameters overridden as optional.
- Add a focused Xquik `searchTweets` OpenAPI fixture.
- Cover its server prefix, auth alternatives, parameters, and response mapping.

The independent fix prevents stale path-level schemas and requiredness from
surviving an operation override.

## Validation

- Focused mapper tests: 6 passed.
- Unit suite: 379 passed.
- Runtime MSW suite: 46 passed.
- Runtime client matrix: 64 passed.
- Typecheck matrix: 39 passed.
- TSTyche: 296 tests and 449 assertions passed.
- Attest type tests and benchmark thresholds passed.
- Package build, package typecheck, and CI typecheck passed.
- Web suite: 6 passed.
- Changed-file formatting passed.
- GitHub reports the PR mergeable and conflict-free.

GitHub's Build and Test workflow awaits approval to run fork code. Vercel's
package preview awaits team authorization. The docs preview is unaffected and
passes. Both remaining statuses require repository-owner action.

Xquik is an independent third-party service. Not affiliated with X Corp.
"Twitter" and "X" are trademarks of X Corp.
