### PR TITLE
feat: transformSchema hook

### DIFF
--- a/.changeset/calm-snails-transform.md
+++ b/.changeset/calm-snails-transform.md
@@ -1,0 +1,5 @@
+---
+"typed-openapi": minor
+---
+
+Add a `transformSchema` option for custom type and runtime transforms, expressible in TS/JS config files via `defineConfig`. The callback runs on each OpenAPI SchemaObject before IR conversion and can return `{ type }`, `{ runtime }`, or both to override the generated TypeScript and/or the runtime validator expression — for example branding integers, mapping `format: date-time` to `Temporal.Instant`, or supplying a per-runtime validator.

--- a/docs/src/content/docs/validation/input-output.md
+++ b/docs/src/content/docs/validation/input-output.md
@@ -116,6 +116,43 @@ pnpm exec typed-openapi openapi.yaml \
 - `format: int64` becomes `bigint`.
 - With the types-only runtime, ISO date strings are revived for the generated client path.
 
+## Custom transforms
+
+When a format, `x-` vendor extension, or naming convention needs a bespoke type — a branded integer, a `Temporal.Instant` instead of `Date`, a domain enum — supply a `transformSchema` callback in a TS/JS config file:
+
+```ts
+// typed-openapi.config.ts
+import { defineConfig } from "typed-openapi";
+
+export default defineConfig({
+  input: "./openapi.yaml",
+  runtime: "zod",
+  transformSchema: (schema) => {
+    if (schema.type === "integer" && schema.format === "int64") {
+      return {
+        type: "number & { readonly __brand: \"IntId\" }",
+        runtime: "z.number().int()",
+      };
+    }
+    if (schema.type === "string" && schema.format === "date-time") {
+      return { type: "Temporal.Instant" };
+    }
+    return undefined;
+  },
+});
+```
+
+The callback runs on every OpenAPI SchemaObject (including nested properties and `$ref` targets) before the internal IR conversion, so it can match on `type`, `format`, `enum`, `x-` extensions, and more. It returns one of:
+
+- `{ type }` — override the generated TypeScript. With a runtime adapter, validation stays permissive and the schema is typed as the declared type.
+- `{ runtime }` — override the runtime validator expression for the active runtime, keeping the default type.
+- `{ type, runtime }` — override both.
+- `undefined` — leave the default emission untouched.
+
+Because config files are validated as plain data, `transformSchema` is only expressible in TypeScript/JavaScript config files via `defineConfig` — it cannot be written in JSON configs or passed as a CLI flag.
+
+The `runtime` expression must be valid for the active runtime adapter (`z.*` for zod, `S.*`/`Schema.*` for effect, `v.*` for valibot, and so on). For the types-only runtime, only `type` is used.
+
 ## Defaults and read/write fields
 
 OpenAPI `default` values are emitted in runtime schemas. For inline request objects, `readOnly` properties are removed from input schemas; for inline response objects, `writeOnly` properties are removed from output schemas. Named `$ref` components remain shared so a component’s public shape does not silently differ between endpoints.

--- a/docs/src/content/docs/validation/input-output.md
+++ b/docs/src/content/docs/validation/input-output.md
@@ -153,6 +153,8 @@ Because config files are validated as plain data, `transformSchema` is only expr
 
 The `runtime` expression must be valid for the active runtime adapter (`z.*` for zod, `S.*`/`Schema.*` for effect, `v.*` for valibot, and so on). For the types-only runtime, only `type` is used.
 
+> **Type-only transforms are a deliberate tradeoff.** When you return `{ type }` alone and a runtime adapter is active, the generated validator no longer checks the original OpenAPI shape — it is a permissive placeholder typed as the declared type (for example `z.unknown() as unknown as z.ZodType<Foo>`). The transform *types* the boundary without *enforcing* it at runtime. If you need both, return `{ type, runtime }` and supply a validator that actually produces the transformed value (e.g. `z.string().transform((s) => Temporal.Instant.from(s))`), or keep `runtime: "none"` for a types-only client.
+
 ## Defaults and read/write fields
 
 OpenAPI `default` values are emitted in runtime schemas. For inline request objects, `readOnly` properties are removed from input schemas; for inline response objects, `writeOnly` properties are removed from output schemas. Named `$ref` components remain shared so a component’s public shape does not silently differ between endpoints.

--- a/packages/typed-openapi/src/config.ts
+++ b/packages/typed-openapi/src/config.ts
@@ -4,6 +4,7 @@ import { extname, resolve } from "pathe";
 import { type } from "arktype";
 import type { ValidationPreset, ValidationPolicy } from "./runtimes/validation.ts";
 import { resolveValidationPolicy } from "./runtimes/validation.ts";
+import type { SchemaTransform } from "./types.ts";
 
 const validationOverrideSchema = type({
   "preset?": "'loose' | 'formats' | 'strict'",
@@ -49,9 +50,17 @@ export const configFileSchema = type({
   "transformDates?": "boolean",
   "transformBigInt?": "boolean",
   "runtimeTypes?": "boolean",
+  /**
+   * Custom schema transform (function). Passed through as-is by ArkType (`unknown`).
+   * Only expressible in TS/JS config files (via `defineConfig`) — not in JSON configs.
+   */
+  "transformSchema?": "unknown",
 });
 
-export type TypedOpenapiConfigFile = typeof configFileSchema.infer;
+export type TypedOpenapiConfigFile = typeof configFileSchema.infer & {
+  /** Custom schema transform; see `SchemaTransform`. */
+  transformSchema?: SchemaTransform;
+};
 
 /** Full config type for `defineConfig` / `typed-openapi.config.ts`. */
 export type TypedOpenapiConfig = TypedOpenapiConfigFile;
@@ -89,7 +98,8 @@ const parseAndValidate = (path: string, parsed: unknown): TypedOpenapiConfigFile
   if (result instanceof type.errors) {
     throw new Error(`Invalid config file ${path}:\n${result.summary}`);
   }
-  return result;
+  // `transformSchema` is passed through by ArkType as `unknown`; retype to the callback signature.
+  return result as TypedOpenapiConfigFile;
 };
 
 /** Sync JSON config load (legacy). Prefer `loadConfig` for TS/JS configs. */

--- a/packages/typed-openapi/src/generate-client-files.ts
+++ b/packages/typed-openapi/src/generate-client-files.ts
@@ -79,6 +79,8 @@ export const optionsSchema = type({
 
 export type GenerateClientFilesOptions = typeof optionsSchema.infer & {
   nameTransform?: NameTransformOptions;
+  /** Custom schema transform (function). See `SchemaTransform`. Config files only (TS/JS). */
+  transformSchema?: GeneratorOptions["transformSchema"];
   /** From CLI `--endpoint` (cac may pass string | string[]) */
   endpoint?: string | string[];
   /** From CLI `--schema` */
@@ -151,7 +153,10 @@ export async function generateClientFiles(input: string | undefined, options: Ge
   }
   const openApiDoc = (await SwaggerParser.bundle(resolvedInput)) as OpenAPIObject;
 
-  const ctx = mapOpenApiEndpoints(openApiDoc, merged);
+  const ctx = mapOpenApiEndpoints(openApiDoc, {
+    ...(merged.nameTransform ? { nameTransform: merged.nameTransform } : {}),
+    ...(merged.transformSchema ? { transformSchema: merged.transformSchema } : {}),
+  });
   console.log(`Found ${ctx.endpointList.length} endpoints`);
 
   // Parse success status codes if provided
@@ -182,6 +187,7 @@ export async function generateClientFiles(input: string | undefined, options: Ge
     ...(validation ? { validation } : {}),
     schemasOnly: merged.schemasOnly ?? false,
     ...(options.nameTransform ? { nameTransform: options.nameTransform } : {}),
+    ...(merged.transformSchema ? { transformSchema: merged.transformSchema } : {}),
     includeClient: includeClient ?? true,
     jsdoc,
     includeDescriptions,

--- a/packages/typed-openapi/src/generator.ts
+++ b/packages/typed-openapi/src/generator.ts
@@ -225,7 +225,6 @@ export const generateRuntimeTypeDeclarations = (options: GeneratorOptions): stri
   const typeContext = { ...ctx, runtime: "none" as const } as GeneratorContext;
   return `${generateSchemaList(typeContext)}${generateEndpointSchemaList(typeContext)}${generateEndpointByMethod(typeContext)}`;
 };
-
 export const generateFile = (options: GeneratorOptions) => {
   const ctx = createGeneratorContext(options);
 

--- a/packages/typed-openapi/src/generator.ts
+++ b/packages/typed-openapi/src/generator.ts
@@ -2,7 +2,7 @@ import { capitalize, groupBy } from "pastable/server";
 import { mapOpenApiEndpoints } from "./map-openapi-endpoints.ts";
 import { type } from "arktype";
 import { wrapWithQuotesIfNeeded } from "./string-utils.ts";
-import type { NameTransformOptions } from "./types.ts";
+import type { NameTransformOptions, SchemaTransform } from "./types.ts";
 import { emitRuntimeFile } from "./runtimes/emit-runtime-file.ts";
 import { getRuntimeAdapter, type ShippedRuntime } from "./runtimes/registry.ts";
 import { resolveValidationPolicy, type ValidationPreset, type ValidationPolicy } from "./runtimes/validation.ts";
@@ -43,6 +43,8 @@ export type GeneratorOptions = ReturnType<typeof mapOpenApiEndpoints> &
     validateSide?: "none" | "input" | "output" | "both";
     schemasOnly?: boolean;
     nameTransform?: NameTransformOptions | undefined;
+    /** Custom schema transform (type + optional runtime expression). See `SchemaTransform`. */
+    transformSchema?: SchemaTransform | undefined;
     successStatusCodes?: readonly number[];
     errorStatusCodes?: readonly number[];
     includeClient?: boolean;
@@ -589,6 +591,9 @@ const collectTransformFieldKeys = (
       return;
     case "record":
       collectTransformFieldKeys(node.value, dateKeys, bigintKeys, schemaByName, resolving, currentKey);
+      return;
+    case "custom":
+      // Custom nodes may still carry a runtime transform; field keys can't be statically known.
       return;
     case "ref": {
       if (resolving.has(node.name)) return;

--- a/packages/typed-openapi/src/map-openapi-endpoints.ts
+++ b/packages/typed-openapi/src/map-openapi-endpoints.ts
@@ -7,6 +7,7 @@ import { stripReadWrite } from "./schema-ir/read-write.ts";
 import type { SchemaIrConvertContext, SchemaNode } from "./schema-ir/types.ts";
 import { pathToVariableName } from "./string-utils.ts";
 import { NameTransformOptions } from "./types.ts";
+import type { SchemaTransform } from "./schema-transform.ts";
 import { match, P } from "ts-pattern";
 import { sanitizeName } from "./sanitize-name.ts";
 
@@ -33,9 +34,15 @@ const schemaFromParameter = (param: ParameterObject): unknown => {
 
 type ParamLocation = "query" | "path" | "header" | "cookie";
 
-export const mapOpenApiEndpoints = (doc: OpenAPIObject, options?: { nameTransform?: NameTransformOptions }) => {
-  const refs = createRefResolver(doc, options?.nameTransform);
-  const irCtx: SchemaIrConvertContext = { getRefName: (ref) => refs.getInfosByRef(ref).normalized };
+export const mapOpenApiEndpoints = (
+  doc: OpenAPIObject,
+  options?: { nameTransform?: NameTransformOptions; transformSchema?: SchemaTransform },
+) => {
+  const refs = createRefResolver(doc, options?.nameTransform, options?.transformSchema);
+  const irCtx: SchemaIrConvertContext = {
+    getRefName: (ref) => refs.getInfosByRef(ref).normalized,
+    ...(options?.transformSchema ? { transformSchema: options.transformSchema } : {}),
+  };
   const endpointList = [] as Array<Endpoint>;
   const endpointAliases = new Set<string>();
 

--- a/packages/typed-openapi/src/msw.generator.ts
+++ b/packages/typed-openapi/src/msw.generator.ts
@@ -158,6 +158,9 @@ export const stubFromSchema = (
     }
     case "record":
       return {};
+    case "custom":
+      // Custom transforms are opaque to MSW stub generation.
+      return null;
     case "binary":
       return null;
     case "stream":

--- a/packages/typed-openapi/src/ref-resolver.ts
+++ b/packages/typed-openapi/src/ref-resolver.ts
@@ -28,7 +28,11 @@ export type RefInfo = {
   kind: "schemas" | "responses" | "parameters" | "requestBodies" | "headers";
 };
 
-export const createRefResolver = (doc: OpenAPIObject, nameTransform?: NameTransformOptions) => {
+export const createRefResolver = (
+  doc: OpenAPIObject,
+  nameTransform?: NameTransformOptions,
+  transformSchema?: SchemaIrConvertContext["transformSchema"],
+) => {
   // both used for debugging purpose
   const nameByRef = new Map<string, string>();
   const refByName = new Map<string, string>();
@@ -124,11 +128,14 @@ export const createRefResolver = (doc: OpenAPIObject, nameTransform?: NameTransf
 
   const directDependencies = new Map<string, Set<string>>();
 
-  const irCtx: SchemaIrConvertContext = { getRefName: (ref) => getInfosByRef(ref).normalized };
+  const irCtx: SchemaIrConvertContext = {
+    getRefName: (ref) => getInfosByRef(ref).normalized,
+    ...(transformSchema ? { transformSchema } : {}),
+  };
 
   const registerSchemaNode = (ref: string) => {
     const schema = getSchemaByRef(ref);
-    nodeByRef.set(ref, openApiToIr(schema, irCtx));
+    nodeByRef.set(ref, openApiToIr(schema, { ...irCtx, ref, path: [`#/components/.../${ref.split("/").pop()}`] }));
 
     if (!directDependencies.has(ref)) {
       directDependencies.set(ref, new Set<string>());

--- a/packages/typed-openapi/src/runtimes/arktype/index.ts
+++ b/packages/typed-openapi/src/runtimes/arktype/index.ts
@@ -288,8 +288,7 @@ export const arktypeAdapter: RuntimeAdapter = {
   imports: () => `import { type } from "arktype";`,
   inferType: (expr) => `${expr}["infer"]`,
   schemaType: (typeReference) => `import("arktype").Type<${typeReference}>`,
-  annotateSchema: (schemaExpr, typeReference) =>
-    `${schemaExpr} as unknown as import("arktype").Type<${typeReference}>`,
+  annotateSchema: (schemaExpr, typeReference) => `${schemaExpr} as unknown as import("arktype").Type<${typeReference}>`,
   emitNode,
   wrapLazy: (_name, body) => body,
   literalString: (value) => `type(${arkUnitDef(value)})`,

--- a/packages/typed-openapi/src/runtimes/arktype/index.ts
+++ b/packages/typed-openapi/src/runtimes/arktype/index.ts
@@ -235,6 +235,9 @@ const emitNode = (node: SchemaNode, ctx: EmitCtx): string => {
       if (node.partial) expr = `${expr}.partial()`;
       return expr;
     }
+    case "custom":
+      if (node.runtime) return node.runtime;
+      return `type.unknown() as unknown as import("arktype").Type<${node.type ?? "unknown"}>`;
     default: {
       const _e: never = node;
       return _e;

--- a/packages/typed-openapi/src/runtimes/effect/index.ts
+++ b/packages/typed-openapi/src/runtimes/effect/index.ts
@@ -300,6 +300,9 @@ const emitNodeInner = (node: SchemaNode, ctx: EmitCtx): string => {
       if (oc.maxProperties !== undefined) filters.push(`${S}.isMaxProperties(${oc.maxProperties})`);
       return checkFilters(expr, filters);
     }
+    case "custom":
+      if (node.runtime) return node.runtime;
+      return `${S}.Unknown as unknown as ${S}.Schema<${node.type ?? "unknown"}, unknown>`;
     default: {
       const _e: never = node;
       return _e;
@@ -309,7 +312,7 @@ const emitNodeInner = (node: SchemaNode, ctx: EmitCtx): string => {
 
 const emitNode = (node: SchemaNode, ctx: EmitCtx): string => {
   const inner = emitNodeInner(node, ctx);
-  if (ctx.omitDefaults || node.meta.default === undefined) return inner;
+  if (ctx.omitDefaults || node.meta.default === undefined || node.kind === "custom") return inner;
   // Object/struct defaults are applied per-property via withDecodingDefaultType.
   if (node.kind === "object") return inner;
   return internEffectDefault(inner, node.meta, S, ctx, "value", "v4", node) ?? inner;

--- a/packages/typed-openapi/src/runtimes/effect3/index.ts
+++ b/packages/typed-openapi/src/runtimes/effect3/index.ts
@@ -234,8 +234,7 @@ export const effect3Adapter: RuntimeAdapter = {
   imports: () => `import { Schema as S } from "@effect/schema";`,
   inferType: (expr) => `S.Schema.Type<typeof ${expr}>`,
   schemaType: (typeReference) => `S.Schema<${typeReference}, unknown>`,
-  annotateSchema: (schemaExpr, typeReference) =>
-    `${schemaExpr} as unknown as S.Schema<${typeReference}, unknown>`,
+  annotateSchema: (schemaExpr, typeReference) => `${schemaExpr} as unknown as S.Schema<${typeReference}, unknown>`,
   emitNode,
   wrapLazy: (_name, body) => `${S}.suspend(() => ${body})`,
   literalString: (value) => `${S}.Literal(${quote(value)})`,

--- a/packages/typed-openapi/src/runtimes/effect3/index.ts
+++ b/packages/typed-openapi/src/runtimes/effect3/index.ts
@@ -212,6 +212,9 @@ const emitNodeInner = (node: SchemaNode, ctx: EmitCtx): string => {
       }
       return pipeFilters(expr, filters);
     }
+    case "custom":
+      if (node.runtime) return node.runtime;
+      return `${S}.Unknown as unknown as ${S}.Schema<${node.type ?? "unknown"}, unknown>`;
     default: {
       const _e: never = node;
       return _e;
@@ -221,7 +224,7 @@ const emitNodeInner = (node: SchemaNode, ctx: EmitCtx): string => {
 
 const emitNode = (node: SchemaNode, ctx: EmitCtx): string => {
   const inner = emitNodeInner(node, ctx);
-  if (ctx.omitDefaults || node.meta.default === undefined) return inner;
+  if (ctx.omitDefaults || node.meta.default === undefined || node.kind === "custom") return inner;
   if (node.kind === "object") return inner;
   return internEffectDefault(inner, node.meta, S, ctx, "value") ?? inner;
 };

--- a/packages/typed-openapi/src/runtimes/shared.ts
+++ b/packages/typed-openapi/src/runtimes/shared.ts
@@ -195,8 +195,7 @@ export const internEffectDefault = (
     name = `${name}_${map.size}`;
   }
 
-  const base =
-    api === "v4" && node && containsNamedRef(node) ? `Schema.suspend(() => ${baseExpr})` : baseExpr;
+  const base = api === "v4" && node && containsNamedRef(node) ? `Schema.suspend(() => ${baseExpr})` : baseExpr;
   const decl =
     api === "v4"
       ? `const ${name} = ${base}.pipe(${schemaNs}.withDecodingDefaultType(Effect.succeed(${lit})));`

--- a/packages/typed-openapi/src/runtimes/shared.ts
+++ b/packages/typed-openapi/src/runtimes/shared.ts
@@ -135,6 +135,9 @@ export const containsNamedRef = (node: SchemaNode): boolean => {
       return containsNamedRef(node.schema);
     case "record":
       return containsNamedRef(node.key) || containsNamedRef(node.value);
+    case "custom":
+      // Custom nodes are opaque strings — no named refs to resolve inside them.
+      return false;
     default:
       return false;
   }
@@ -371,6 +374,8 @@ export const findRecursiveSchemaNames = (schemas: Array<{ name: string; node: Sc
       case "record":
         refsIn(node.key, into);
         refsIn(node.value, into);
+        break;
+      case "custom":
         break;
       default:
         break;

--- a/packages/typed-openapi/src/runtimes/typebox/index.ts
+++ b/packages/typed-openapi/src/runtimes/typebox/index.ts
@@ -139,6 +139,10 @@ const emitNodeInner = (node: SchemaNode, ctx: EmitCtx): string => {
       if (node.partial) expr = `Type.Partial(${expr})`;
       return expr;
     }
+    case "custom":
+      if (node.runtime) return node.runtime;
+      // `Type.Unsafe<T>` yields Static = T (accepts anything at runtime, like a type-only transform).
+      return `Type.Unsafe<${node.type ?? "unknown"}>({ type: "unknown" })`;
     default: {
       const _exhaustive: never = node;
       return _exhaustive;

--- a/packages/typed-openapi/src/runtimes/typia/index.ts
+++ b/packages/typed-openapi/src/runtimes/typia/index.ts
@@ -63,6 +63,10 @@ const typiaTypeExpr = (node: SchemaNode, ctx: EmitCtx): string => {
         return node.name;
       }
       return toTs(node, ctx);
+    case "custom":
+      if (node.runtime) return node.runtime;
+      // typia can generate a guard directly from the declared type.
+      return `typia.createIs<${node.type ?? "unknown"}>()`;
     default:
       return toTs(node, ctx);
   }

--- a/packages/typed-openapi/src/runtimes/valibot/index.ts
+++ b/packages/typed-openapi/src/runtimes/valibot/index.ts
@@ -159,6 +159,9 @@ const emitNodeInner = (node: SchemaNode, ctx: EmitCtx): string => {
       }
       return pipe(expr, actions);
     }
+    case "custom":
+      if (node.runtime) return node.runtime;
+      return `v.unknown() as unknown as v.GenericSchema<${node.type ?? "unknown"}>`;
     default: {
       const _e: never = node;
       return _e;
@@ -166,7 +169,8 @@ const emitNodeInner = (node: SchemaNode, ctx: EmitCtx): string => {
   }
 };
 
-const emitNode = (node: SchemaNode, ctx: EmitCtx): string => withValibotDefault(emitNodeInner(node, ctx), node.meta);
+const emitNode = (node: SchemaNode, ctx: EmitCtx): string =>
+  node.kind === "custom" ? emitNodeInner(node, ctx) : withValibotDefault(emitNodeInner(node, ctx), node.meta);
 
 export const valibotAdapter: RuntimeAdapter = {
   name: "valibot",

--- a/packages/typed-openapi/src/runtimes/zod/index.ts
+++ b/packages/typed-openapi/src/runtimes/zod/index.ts
@@ -177,6 +177,10 @@ const emitNodeInner = (node: SchemaNode, ctx: EmitCtx): string => {
       }
       return expr;
     }
+    case "custom":
+      if (node.runtime) return node.runtime;
+      // Type-only transform: keep validation permissive but declare the transformed output type.
+      return `z.unknown() as unknown as z.ZodType<${node.type ?? "unknown"}>`;
     default: {
       const _e: never = node;
       return _e;
@@ -185,7 +189,9 @@ const emitNodeInner = (node: SchemaNode, ctx: EmitCtx): string => {
 };
 
 const emitNode = (node: SchemaNode, ctx: EmitCtx): string =>
-  withZodDescription(withZodDefault(emitNodeInner(node, ctx), node.meta), node.meta, ctx.includeDescriptions);
+  node.kind === "custom"
+    ? emitNodeInner(node, ctx)
+    : withZodDescription(withZodDefault(emitNodeInner(node, ctx), node.meta), node.meta, ctx.includeDescriptions);
 
 export const zodAdapter: RuntimeAdapter = {
   name: "zod",

--- a/packages/typed-openapi/src/runtimes/zod3/index.ts
+++ b/packages/typed-openapi/src/runtimes/zod3/index.ts
@@ -165,6 +165,9 @@ const emitNodeInner = (node: SchemaNode, ctx: EmitCtx): string => {
       }
       return expr;
     }
+    case "custom":
+      if (node.runtime) return node.runtime;
+      return `z.unknown() as unknown as z.ZodType<${node.type ?? "unknown"}>`;
     default: {
       const _e: never = node;
       return _e;
@@ -173,7 +176,9 @@ const emitNodeInner = (node: SchemaNode, ctx: EmitCtx): string => {
 };
 
 const emitNode = (node: SchemaNode, ctx: EmitCtx): string =>
-  withZodDescription(withZodDefault(emitNodeInner(node, ctx), node.meta), node.meta, ctx.includeDescriptions);
+  node.kind === "custom"
+    ? emitNodeInner(node, ctx)
+    : withZodDescription(withZodDefault(emitNodeInner(node, ctx), node.meta), node.meta, ctx.includeDescriptions);
 
 export const zod3Adapter: RuntimeAdapter = {
   name: "zod3",

--- a/packages/typed-openapi/src/schema-ir/ir-to-ts.ts
+++ b/packages/typed-openapi/src/schema-ir/ir-to-ts.ts
@@ -114,6 +114,9 @@ export const irToTs = (node: SchemaNode, options: IrToTsOptions = {}): string =>
     }
     case "record":
       return `Record<${irToTs(node.key, { ...options, prefixRefsWithSchemas: false })}, ${irToTs(node.value, options)}>`;
+    case "custom":
+      // User-supplied transform type; falls back to the default-rendered type when only a runtime transform was given.
+      return node.type ?? (node.fallback ? irToTs(node.fallback, options) : "unknown");
     case "object": {
       const entries = Object.entries(node.properties);
       const rendered = entries.map(([prop, propNode]) => {
@@ -164,6 +167,7 @@ export const renderSchemaJsdoc = (description: string | undefined) =>
 /** Object/record shapes that can be declared as `interface` (breaks TS2456 cycles). */
 export const canEmitAsInterface = (node: SchemaNode): boolean => {
   if (node.kind === "record") return true;
+  if (node.kind === "custom") return false;
   if (node.kind === "object" && !node.partial && node.additionalProperties === false) return true;
   return false;
 };
@@ -180,6 +184,10 @@ export const emitNamedInterface = (name: string, node: SchemaNode, options: IrTo
       return `export interface ${name} { [key: string]: ${value} }`;
     }
     return `export type ${name} = Record<${keyTs}, ${value}>`;
+  }
+
+  if (node.kind === "custom") {
+    return `export type ${name} = ${node.type ?? (node.fallback ? irToTs(node.fallback, options) : "unknown")};`;
   }
 
   if (node.kind === "object") {

--- a/packages/typed-openapi/src/schema-ir/openapi-to-ir.ts
+++ b/packages/typed-openapi/src/schema-ir/openapi-to-ir.ts
@@ -128,10 +128,35 @@ const enumToIr = (values: unknown[], meta: SchemaMeta): SchemaNode => {
 };
 
 export const openApiToIr = (input: unknown, ctx: SchemaIrConvertContext): SchemaNode => {
+  return openApiToIrInternal(input, ctx, ctx.path ?? []);
+};
+
+const openApiToIrInternal = (input: unknown, ctx: SchemaIrConvertContext, path: string[]): SchemaNode => {
   if (!input) {
     return { kind: "unknown", meta: emptyMeta() };
   }
 
+  const transformCtx = { path, ...(ctx.ref !== undefined ? { ref: ctx.ref } : {}) };
+  const transformResult =
+    ctx.transformSchema && input && typeof input === "object"
+      ? ctx.transformSchema(input as LibSchemaObject, transformCtx)
+      : undefined;
+  if (transformResult && (transformResult.type !== undefined || transformResult.runtime !== undefined)) {
+    // Runtime-only transforms keep the default type; compute the default node as fallback.
+    const fallback = transformResult.type === undefined ? openApiToIrInnerBody(input, ctx, path) : undefined;
+    return {
+      kind: "custom",
+      type: transformResult.type,
+      runtime: transformResult.runtime,
+      ...(fallback ? { fallback } : {}),
+      meta: isReferenceObject(input) ? emptyMeta() : extractMeta(input as LibSchemaObject),
+    };
+  }
+
+  return openApiToIrInnerBody(input, ctx, path);
+};
+
+const openApiToIrInnerBody = (input: unknown, ctx: SchemaIrConvertContext, path: string[]): SchemaNode => {
   if (isReferenceObject(input)) {
     return { kind: "ref", name: ctx.getRefName(input.$ref), meta: emptyMeta() };
   }
@@ -146,14 +171,14 @@ export const openApiToIr = (input: unknown, ctx: SchemaIrConvertContext): Schema
 
   if (Array.isArray(schema.type)) {
     if (schema.type.length === 1) {
-      return openApiToIr({ ...schema, type: schema.type[0]! }, ctx);
+      return openApiToIrInternal({ ...schema, type: schema.type[0]! }, ctx, path);
     }
     return withNullable(
       {
         kind: "union",
         members: schema.type.map((prop: string) => {
           const { nullable: _n, ...rest } = schema;
-          return openApiToIr({ ...rest, type: prop }, ctx);
+          return openApiToIrInternal({ ...rest, type: prop }, ctx, path);
         }),
         meta,
       },
@@ -166,7 +191,7 @@ export const openApiToIr = (input: unknown, ctx: SchemaIrConvertContext): Schema
   }
 
   if (schema.not) {
-    return withNullable({ kind: "not", schema: openApiToIr(schema.not, ctx), meta }, schema);
+    return withNullable({ kind: "not", schema: openApiToIrInternal(schema.not, ctx, [...path, "not"]), meta }, schema);
   }
 
   const discriminator =
@@ -179,12 +204,12 @@ export const openApiToIr = (input: unknown, ctx: SchemaIrConvertContext): Schema
 
   if (schema.oneOf) {
     if (schema.oneOf.length === 1) {
-      return withNullable(openApiToIr(schema.oneOf[0]!, ctx), schema);
+      return withNullable(openApiToIrInternal(schema.oneOf[0]!, ctx, [...path, "oneOf", "0"]), schema);
     }
     return withNullable(
       {
         kind: "union",
-        members: schema.oneOf.map((prop: unknown) => openApiToIr(prop, ctx)),
+        members: schema.oneOf.map((prop: unknown, i) => openApiToIrInternal(prop, ctx, [...path, "oneOf", String(i)])),
         meta,
         ...(discriminator ? { discriminator } : {}),
       },
@@ -194,12 +219,12 @@ export const openApiToIr = (input: unknown, ctx: SchemaIrConvertContext): Schema
 
   if (schema.anyOf) {
     if (schema.anyOf.length === 1) {
-      return withNullable(openApiToIr(schema.anyOf[0]!, ctx), schema);
+      return withNullable(openApiToIrInternal(schema.anyOf[0]!, ctx, [...path, "anyOf", "0"]), schema);
     }
     return withNullable(
       {
         kind: "union",
-        members: schema.anyOf.map((prop: unknown) => openApiToIr(prop, ctx)),
+        members: schema.anyOf.map((prop: unknown, i) => openApiToIrInternal(prop, ctx, [...path, "anyOf", String(i)])),
         meta,
         ...(discriminator ? { discriminator } : {}),
       },
@@ -208,10 +233,12 @@ export const openApiToIr = (input: unknown, ctx: SchemaIrConvertContext): Schema
   }
 
   if (schema.allOf) {
-    const members = schema.allOf.map((prop: unknown) => openApiToIr(prop, ctx));
+    const members = schema.allOf.map((prop: unknown, i) =>
+      openApiToIrInternal(prop, ctx, [...path, "allOf", String(i)]),
+    );
     const { allOf: _a, externalDocs: _e, example: _ex, examples: _xs, description: _d, title: _t, ...rest } = schema;
     if (Object.keys(rest).filter((k) => k !== "nullable").length > 0) {
-      members.push(openApiToIr(rest as LibSchemaObject, ctx));
+      members.push(openApiToIrInternal(rest as LibSchemaObject, ctx, path));
     }
     return withNullable({ kind: "intersection", members, meta }, schema);
   }
@@ -219,8 +246,10 @@ export const openApiToIr = (input: unknown, ctx: SchemaIrConvertContext): Schema
   // OAS 3.1 prefixItems → tuple
   if (schema.type === "array" && Array.isArray((schema as { prefixItems?: unknown }).prefixItems)) {
     const prefixItems = (schema as { prefixItems: Array<LibSchemaObject | ReferenceObject> }).prefixItems;
-    const items = prefixItems.map((item: unknown) => openApiToIr(item, ctx));
-    const restNode = schema.items ? openApiToIr(schema.items, ctx) : undefined;
+    const items = prefixItems.map((item: unknown, i) =>
+      openApiToIrInternal(item, ctx, [...path, "prefixItems", String(i)]),
+    );
+    const restNode = schema.items ? openApiToIrInternal(schema.items, ctx, [...path, "items"]) : undefined;
     const tupleNode: SchemaNode =
       restNode === undefined ? { kind: "tuple", items, meta } : { kind: "tuple", items, rest: restNode, meta };
     return withNullable(tupleNode, schema);
@@ -264,7 +293,9 @@ export const openApiToIr = (input: unknown, ctx: SchemaIrConvertContext): Schema
   }
 
   if (schemaType === "array") {
-    const items = schema.items ? openApiToIr(schema.items, ctx) : ({ kind: "any", meta: emptyMeta() } as SchemaNode);
+    const items = schema.items
+      ? openApiToIrInternal(schema.items, ctx, [...path, "items"])
+      : ({ kind: "any", meta: emptyMeta() } as SchemaNode);
     return withNullable({ kind: "array", items, constraints: arrayConstraints(schema), meta }, schema);
   }
 
@@ -275,7 +306,7 @@ export const openApiToIr = (input: unknown, ctx: SchemaIrConvertContext): Schema
           {
             kind: "record",
             key: { kind: "string", constraints: {}, meta: emptyMeta() },
-            value: openApiToIr(schema.additionalProperties, ctx),
+            value: openApiToIrInternal(schema.additionalProperties, ctx, [...path, "additionalProperties"]),
             meta,
           },
           schema,
@@ -299,7 +330,7 @@ export const openApiToIr = (input: unknown, ctx: SchemaIrConvertContext): Schema
     ) {
       additionalProperties = true;
     } else if (typeof schema.additionalProperties === "object") {
-      additionalProperties = openApiToIr(schema.additionalProperties, ctx);
+      additionalProperties = openApiToIrInternal(schema.additionalProperties, ctx, [...path, "additionalProperties"]);
     }
 
     const hasRequiredArray = Boolean(schema.required && schema.required.length > 0);
@@ -307,7 +338,7 @@ export const openApiToIr = (input: unknown, ctx: SchemaIrConvertContext): Schema
 
     const properties: Record<string, SchemaNode> = {};
     for (const [prop, propSchema] of Object.entries(schema.properties)) {
-      properties[prop] = openApiToIr(propSchema, ctx);
+      properties[prop] = openApiToIrInternal(propSchema, ctx, [...path, "properties", prop]);
     }
 
     const required = isPartial ? [] : hasRequiredArray ? [...(schema.required ?? [])] : Object.keys(properties);

--- a/packages/typed-openapi/src/schema-ir/types.ts
+++ b/packages/typed-openapi/src/schema-ir/types.ts
@@ -1,3 +1,5 @@
+import type { LibSchemaObject, SchemaTransformResult } from "../schema-transform.ts";
+
 export type SchemaMeta = {
   description?: string;
   title?: string;
@@ -78,8 +80,29 @@ export type SchemaNode =
   | { kind: "stream"; meta: SchemaMeta }
   | { kind: "unknown"; meta: SchemaMeta }
   | { kind: "any"; meta: SchemaMeta }
-  | { kind: "never"; meta: SchemaMeta };
+  | { kind: "never"; meta: SchemaMeta }
+  /**
+   * User-supplied transform (`transformSchema`): replaces the default type/runtime emission
+   * for a SchemaObject with custom TypeScript (`type`) and/or a runtime validator expression (`runtime`).
+   * When `type` is omitted, the default IR node is kept as `fallback` and rendered instead.
+   */
+  | {
+      kind: "custom";
+      type?: string | undefined;
+      runtime?: string | undefined;
+      fallback?: SchemaNode;
+      meta: SchemaMeta;
+    };
 
 export type SchemaIrConvertContext = {
   getRefName: (ref: string) => string;
+  /** User-supplied schema transform; when it returns a result, the SchemaObject becomes a `custom` node. */
+  transformSchema?: (
+    schema: LibSchemaObject,
+    ctx: { path: string[]; ref?: string },
+  ) => SchemaTransformResult | undefined;
+  /** JSON-pointer-ish path of the SchemaObject being converted (for transform context / debugging). */
+  path?: string[];
+  /** `$ref` of the SchemaObject being converted, when it's a named component. */
+  ref?: string;
 };

--- a/packages/typed-openapi/src/schema-transform.ts
+++ b/packages/typed-openapi/src/schema-transform.ts
@@ -1,0 +1,30 @@
+import type { SchemaObject } from "openapi3-ts/oas31";
+import type { SchemaObject as SchemaObject3 } from "openapi3-ts/oas30";
+
+export type LibSchemaObject = SchemaObject & SchemaObject3;
+
+/**
+ * Result of a user `transformSchema` callback.
+ * - `type`: TypeScript type string replacing the default generated type (e.g. `"Temporal.Instant"`, `"Foo"`).
+ * - `runtime`: runtime validator expression replacing the default one for the active runtime
+ *   (e.g. `"z.string().transform((s) => Temporal.Instant.from(s))"`).
+ * Both are optional; a transform may override only the type, only the runtime, or both.
+ */
+export type SchemaTransformResult = {
+  type?: string;
+  runtime?: string;
+};
+
+/**
+ * User-supplied schema transform, analogous to `openapi-typescript`'s `transform` option.
+ * Runs on the raw OpenAPI SchemaObject (before IR conversion), so it can match on `type`,
+ * `format`, `x-` vendor extensions, `$ref`, etc. Return `undefined` to keep the default emission.
+ *
+ * Because config files are validated as plain data, this callback is only available through
+ * the library API / `defineConfig` in a TS/JS config file — it cannot be expressed in JSON configs
+ * or as a CLI flag.
+ */
+export type SchemaTransform = (
+  schema: LibSchemaObject,
+  ctx: { path: string[]; ref?: string },
+) => SchemaTransformResult | undefined;

--- a/packages/typed-openapi/src/types.ts
+++ b/packages/typed-openapi/src/types.ts
@@ -1,9 +1,8 @@
-import type { OperationObject, SchemaObject } from "openapi3-ts/oas31";
-import type { SchemaObject as SchemaObject3 } from "openapi3-ts/oas30";
+import type { OperationObject } from "openapi3-ts/oas31";
 
 import type { Method } from "./map-openapi-endpoints.ts";
 
-export type LibSchemaObject = SchemaObject & SchemaObject3;
+export type { LibSchemaObject, SchemaTransform, SchemaTransformResult } from "./schema-transform.ts";
 
 export type NameTransformOptions = {
   transformSchemaName?: (name: string) => string;

--- a/packages/typed-openapi/tests/custom-transform.test.ts
+++ b/packages/typed-openapi/tests/custom-transform.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, test } from "vitest";
+import { type } from "arktype";
+import { openApiToIr } from "../src/schema-ir/openapi-to-ir.ts";
+import { irToTs } from "../src/schema-ir/ir-to-ts.ts";
+import { generateFile } from "../src/generator.ts";
+import { mapOpenApiEndpoints } from "../src/map-openapi-endpoints.ts";
+import { configFileSchema } from "../src/config.ts";
+import type { OpenAPIObject } from "openapi3-ts/oas31";
+import { getRuntimeAdapter } from "../src/runtimes/registry.ts";
+import { createEmitCtx } from "../src/runtimes/types.ts";
+import { resolveValidationPolicy } from "../src/runtimes/validation.ts";
+import type { SchemaTransform } from "../src/types.ts";
+
+const irCtx = { getRefName: (ref: string) => ref };
+
+/** Map a number-with-brand-format schema to a branded type + a zod runtime transform. */
+const brandTransform: SchemaTransform = (schema) => {
+  if (schema.type === "number" && schema.format === "brand") {
+    return { type: 'string & { __brand: "foo" }', runtime: "z.string()" };
+  }
+  return undefined;
+};
+
+describe("custom schema transforms (transformSchema)", () => {
+  test("openApiToIr produces a custom node from a transform result", () => {
+    const node = openApiToIr(
+      { type: "number", format: "brand" },
+      {
+        ...irCtx,
+        transformSchema: brandTransform,
+      },
+    );
+    expect(node.kind).toBe("custom");
+    if (node.kind === "custom") {
+      expect(node.type).toBe('string & { __brand: "foo" }');
+      expect(node.runtime).toBe("z.string()");
+    }
+  });
+
+  test("irToTs emits the transform type", () => {
+    const node = openApiToIr(
+      { type: "number", format: "brand" },
+      {
+        ...irCtx,
+        transformSchema: brandTransform,
+      },
+    );
+    expect(irToTs(node)).toBe('string & { __brand: "foo" }');
+  });
+
+  test("transform without a result leaves default emission", () => {
+    const node = openApiToIr({ type: "string" }, { ...irCtx, transformSchema: brandTransform });
+    expect(node.kind).toBe("string");
+  });
+
+  test("runtime-only transform keeps default type but overrides runtime", () => {
+    const node = openApiToIr(
+      { type: "number" },
+      {
+        ...irCtx,
+        transformSchema: () => ({ runtime: "z.any()" }),
+      },
+    );
+    expect(node.kind).toBe("custom");
+    if (node.kind === "custom") {
+      expect(irToTs(node)).toBe("number");
+      expect(node.runtime).toBe("z.any()");
+    }
+  });
+
+  test("runtime adapters emit the transform runtime expression", () => {
+    const node = openApiToIr(
+      { type: "number", format: "brand" },
+      {
+        ...irCtx,
+        transformSchema: brandTransform,
+      },
+    );
+    const ctx = createEmitCtx(resolveValidationPolicy("strict"), new Set());
+    const zod = getRuntimeAdapter("zod");
+    expect(zod.emitNode(node, ctx)).toBe("z.string()");
+    const valibot = getRuntimeAdapter("valibot");
+    expect(valibot.emitNode(node, ctx)).toBe("z.string()"); // runtime expr is raw passthrough
+  });
+
+  test("type-only transform emits per-adapter typed permissive validator", () => {
+    const node = openApiToIr(
+      { type: "number", format: "brand" },
+      {
+        ...irCtx,
+        transformSchema: (schema) =>
+          schema.type === "number" && schema.format === "brand" ? { type: "Foo" } : undefined,
+      },
+    );
+    const ctx = createEmitCtx(resolveValidationPolicy("strict"), new Set());
+
+    const cases: Array<[import("../src/runtimes/types.ts").OutputRuntime, string]> = [
+      ["zod", "z.ZodType<Foo>"],
+      ["zod3", "z.ZodType<Foo>"],
+      ["valibot", "v.GenericSchema<Foo>"],
+      ["effect", "Schema<Foo, unknown>"],
+      ["effect3", "Schema<Foo, unknown>"],
+      ["arktype", 'import("arktype").Type<Foo>'],
+      ["typebox", "Type.Unsafe<Foo>"],
+      ["typia", "typia.createIs<Foo>()"],
+    ];
+    for (const [runtime, needle] of cases) {
+      const adapter = getRuntimeAdapter(runtime);
+      expect(adapter.emitNode(node, ctx)).toContain(needle);
+    }
+  });
+
+  test("generateFile none-runtime uses transform type", () => {
+    const doc = {
+      openapi: "3.0.3",
+      info: { title: "t", version: "1" },
+      paths: {
+        "/thing": {
+          get: {
+            operationId: "getThing",
+            responses: {
+              "200": {
+                description: "ok",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      required: ["id"],
+                      properties: { id: { type: "number", format: "brand" } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as OpenAPIObject;
+
+    const file = generateFile({
+      ...mapOpenApiEndpoints(doc, { transformSchema: brandTransform }),
+      transformSchema: brandTransform,
+    });
+    expect(file).toContain('string & { __brand: "foo" }');
+  });
+
+  test("generateFile zod runtime uses transform runtime expression", () => {
+    const doc = {
+      openapi: "3.0.3",
+      info: { title: "t", version: "1" },
+      paths: {
+        "/thing": {
+          get: {
+            operationId: "getThing",
+            responses: {
+              "200": {
+                description: "ok",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      required: ["id"],
+                      properties: { id: { type: "number", format: "brand" } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as OpenAPIObject;
+
+    const file = generateFile({
+      ...mapOpenApiEndpoints(doc, { transformSchema: brandTransform }),
+      runtime: "zod",
+      transformSchema: brandTransform,
+    });
+    expect(file).toContain("z.string()");
+  });
+
+  test("runtimeTypeDeclarations sidecar carries the transform type", () => {
+    const doc = {
+      openapi: "3.0.3",
+      info: { title: "t", version: "1" },
+      paths: {
+        "/thing": {
+          get: {
+            operationId: "getThing",
+            responses: {
+              "200": {
+                description: "ok",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      required: ["id"],
+                      properties: { id: { type: "number", format: "brand" } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as OpenAPIObject;
+
+    const declarations = generateFile({
+      ...mapOpenApiEndpoints(doc, { transformSchema: brandTransform }),
+      transformSchema: brandTransform,
+      runtimeTypeDeclarations: "./x.types.d.ts",
+    });
+    expect(declarations).toContain('string & { __brand: "foo" }');
+  });
+
+  test("component schemas are transformed via ref resolver", () => {
+    const doc = {
+      openapi: "3.0.3",
+      info: { title: "t", version: "1" },
+      paths: {
+        "/thing": {
+          get: {
+            operationId: "getThing",
+            responses: {
+              "200": {
+                description: "ok",
+                content: { "application/json": { schema: { $ref: "#/components/schemas/Branded" } } },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Branded: { type: "object", required: ["id"], properties: { id: { type: "number", format: "brand" } } },
+        },
+      },
+    } as OpenAPIObject;
+
+    const file = generateFile({
+      ...mapOpenApiEndpoints(doc, { transformSchema: brandTransform }),
+      transformSchema: brandTransform,
+    });
+    expect(file).toContain('string & { __brand: "foo" }');
+  });
+
+  test("config file schema passes transformSchema through", () => {
+    const transform: SchemaTransform = () => undefined;
+    const result = configFileSchema({ input: "./x.yaml", transformSchema: transform });
+    expect(result instanceof type.errors).toBe(false);
+    // `result` is a data object; the function survives ArkType validation.
+    expect(typeof (result as { transformSchema?: unknown }).transformSchema).toBe("function");
+  });
+
+  test("Temporal-style date transform end to end (none runtime)", () => {
+    const temporalTransform: SchemaTransform = (schema) => {
+      if (schema.type === "string" && schema.format === "date-time") {
+        return { type: "Temporal.Instant" };
+      }
+      return undefined;
+    };
+    const doc = {
+      openapi: "3.0.3",
+      info: { title: "t", version: "1" },
+      paths: {
+        "/event": {
+          get: {
+            operationId: "getEvent",
+            responses: {
+              "200": {
+                description: "ok",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      required: ["at"],
+                      properties: { at: { type: "string", format: "date-time" } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as OpenAPIObject;
+
+    const file = generateFile({
+      ...mapOpenApiEndpoints(doc, { transformSchema: temporalTransform }),
+      transformSchema: temporalTransform,
+    });
+    expect(file).toContain("Temporal.Instant");
+    expect(file).not.toContain("__reviveTransforms");
+  });
+});


### PR DESCRIPTION
fix https://github.com/astahmer/typed-openapi/issues/140

**`transformSchema` option — type + runtime transforms, both optional, config-file only (TS/JS).**

- **New `custom` SchemaNode kind** (`schema-ir/types.ts`) carrying `{ type?, runtime?, fallback? }`, plus a new `schema-transform.ts` module defining `SchemaTransform`/`SchemaTransformResult`/`LibSchemaObject` (moved out of `types.ts` to break a dts-bundler circular import).
- **IR hook** in `openApiToIr` (`openapi-to-ir.ts`): the callback runs on every raw SchemaObject (including nested props, `oneOf`/`anyOf`/`allOf`, `additionalProperties`, and `$ref` component targets via `ref-resolver`), threads a `path` context, and:
  - `{ type }` → custom type, runtime validation stays permissive-but-typed.
  - `{ runtime }` → overrides the validator, default type kept via the fallback node.
  - `{ type, runtime }` → both.
  - `undefined` → default emission.
- **Type emission** in `ir-to-ts.ts` (incl. `emitNamedInterface`) and `collectTransformFieldKeys`/`containsNamedRef`/`findRecursiveSchemaNames`/`msw` traversal switches handle `custom` without breaking recursion detection.
- **All 8 runtime adapters** emit the `runtime` expression verbatim, or a per-adapter typed-permissive validator (`z.ZodType<Foo>`, `Schema.Schema<Foo, unknown>`, `Type.Unsafe<Foo>`, `typia.createIs<Foo>()`, etc.) when only `type` is given. Effect/valibot/zod default-wrapping is skipped for custom nodes.
- **Config plumbing**: `configFileSchema` passes functions through via `"transformSchema?": "unknown"`, `defineConfig` types it correctly, `generate-client-files` threads it into both `mapOpenApiEndpoints` and `generateFile`/`generateRuntimeTypeDeclarations`. The `.types.d.ts` sidecar carries the transform types, so runtime clients stay sound.

**Verification:** `tsc -b` build + CI typecheck pass, full unit suite 400/400 green (incl. 12 new tests), oxfmt clean, and an end-to-end CLI run with a config-file transform generated a zod client + sidecar that typecheck under `strict`. Docs section added to `validation/input-output.md` plus a changeset.

The one judgment call worth flagging: a `{ type }`-only transform with a runtime adapter emits a **permissive validator typed as the declared type** — it doesn't validate the original shape. That's the honest tradeoff for types-only transforms when runtime is active; giving a `runtime` expression restores real validation.